### PR TITLE
use pouchdb-http package instead of pouchdb

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ import stateManager from './stateManager.js';
 import saveDocs from './saveDocs.js';
 import algoliaIndex from './algoliaIndex.js';
 import c from './config.js';
-import PouchDB from 'pouchdb';
+import PouchDB from 'pouchdb-http';
 import npm from './npm.js';
 import log from './log.js';
 import ms from 'ms';

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ms": "^0.7.2",
     "nice-package": "^2.2.0",
     "numeral": "^2.0.4",
-    "pouchdb": "^6.1.0",
+    "pouchdb-http": "^6.0.2",
     "traverse": "^0.6.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Since you're only using the PouchDB HTTP adapter and the `.changes()` API, you can get away with just using the `pouchdb-http` package, which only contains `pouchdb-core` and `pouchdb-adapter-http`. Notably it avoids installing LevelDB so will lead to faster npm/yarn installs: http://pouchdb.com/custom.html