### PR TITLE
fix(pkg.readme) don't render markdown

### DIFF
--- a/formatPkg.js
+++ b/formatPkg.js
@@ -4,8 +4,6 @@ import gravatarUrl from 'gravatar-url';
 import numeral from 'numeral';
 const defaultGravatar = 'https://www.gravatar.com/avatar/';
 import escape from 'escape-html';
-import marked from 'marked';
-import xss from 'xss';
 import traverse from 'traverse';
 
 export default function formatPkg(pkg) {
@@ -45,7 +43,7 @@ export default function formatPkg(pkg) {
 
   const _readme = pkg.readme;
   // todo: fetch from github if _readme is undefined
-  const readme = _readme && html({ markdown:_readme, githubRepo, gitHead });
+  const readme = _readme;
 
   return traverse({
     objectID: cleaned.name,
@@ -81,53 +79,6 @@ function maybeEscape(node) {
       this.update(escape(node));
     }
   }
-}
-
-const prefixURL = (url, { base, user, project, head, path }) => {
-  if (url.indexOf('//') > 0) {
-    return url;
-  } else {
-    try {
-      return new URL(
-        (path ? path.replace(/^\//, '') + '/' : '') +
-          url.replace(/^(\.?\/?)/, ''),
-        `${base}/${user}/${project}/${path ? '' : `${head}/`}`,
-      );
-    } catch (e) {
-      return url;
-    }
-  }
-};
-
-function html({markdown, githubRepo, gitHead }) {
-  const renderer = new marked.Renderer();
-
-  if (githubRepo) {
-    const { user, project, path } = githubRepo;
-    renderer.image = function(href, title, text) {
-      return `<img src="${prefixURL(href, {
-        base: 'https://raw.githubusercontent.com',
-        user,
-        project,
-        head: gitHead ? gitHead : 'master',
-        path,
-      })}" title="${title}" alt="${text}"/>`;
-    }
-
-    renderer.link = function(href, title, text) {
-      return `<a href="${prefixURL(href, {
-        base: 'https://github.com',
-        user,
-        project,
-        head: gitHead ? `tree/${gitHead}` : 'tree/master',
-        path,
-      })}" title="${title}">${text}</a>`;
-    }
-  }
-
-  const html = marked(markdown, { renderer });
-  const escaped = xss(html);
-  return escaped;
 }
 
 function getOwner(githubRepo, lastPublisher, author) {

--- a/package.json
+++ b/package.json
@@ -27,13 +27,11 @@
     "got": "^6.7.1",
     "gravatar-url": "^2.0.0",
     "lodash": "^4.17.4",
-    "marked": "^0.3.6",
     "ms": "^0.7.2",
     "nice-package": "^3.0.1",
     "numeral": "^2.0.4",
     "pouchdb-http": "^6.0.2",
-    "traverse": "^0.6.6",
-    "xss": "^0.3.3"
+    "traverse": "^0.6.6"
   },
   "devDependencies": {
     "babel-eslint": "^7.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1218,10 +1218,6 @@ crypto-browserify@^3.11.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
 
-cssfilter@0.0.9:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/cssfilter/-/cssfilter-0.0.9.tgz#8f5ceb3aabd768db539da4582b2152d63ef7715e"
-
 d@^0.1.1, d@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/d/-/d-0.1.1.tgz#da184c535d18d8ee7ba2aa229b914009fae11309"
@@ -2587,10 +2583,6 @@ markdown-to-ast@~3.4.0:
     structured-source "^3.0.2"
     traverse "^0.6.6"
 
-marked@^0.3.6:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
-
 md5-hex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/md5-hex/-/md5-hex-2.0.0.tgz#d0588e9f1c74954492ecd24ac0ac6ce997d92e33"
@@ -3867,13 +3859,6 @@ write@^0.2.1:
   resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
   dependencies:
     mkdirp "^0.5.1"
-
-xss@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/xss/-/xss-0.3.3.tgz#a014360dee10317331f9e74258141f7ed03fc784"
-  dependencies:
-    commander "^2.9.0"
-    cssfilter "0.0.9"
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"


### PR DESCRIPTION
We decided to save bandwidth and place in the Algolia index by storing the raw markdown instead of the rendered and escaped html. The readme isn't been run through `escape-html`, since then we can't render the markdown properly on the client