### PR TITLE
feat(pkg.readme) truncate readmes longer than 450kB

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,6 +1,7 @@
 const defaultConfig = {
   npmRegistryEndpoint: 'https://replicate.npmjs.com/registry',
   npmDownloadsEndpoint: 'https://api.npmjs.org/downloads',
+  maxObjSize: 450000,
   popularDownloadsRatio: 0.005,
   appId: 'OFCNCOG2CU',
   apiKey: '',

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "ms": "^0.7.2",
     "nice-package": "^3.0.1",
     "numeral": "^2.0.4",
+    "object-sizeof": "^1.1.1",
     "pouchdb-http": "^6.0.2",
     "traverse": "^0.6.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2814,6 +2814,10 @@ object-keys@^1.0.10, object-keys@^1.0.11, object-keys@^1.0.8, object-keys@~1.0.0
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
 
+object-sizeof@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/object-sizeof/-/object-sizeof-1.1.1.tgz#3b8ac4e8cb245b1c8eb6f17d5adc90eaf45b4187"
+
 object.assign@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.0.4.tgz#b1c9cc044ef1b9fe63606fc141abbb32e14730cc"


### PR DESCRIPTION
This won't happen often at all, since for now, it should never appear. 

adds ` **TRUNCATED**` to the end of a very long README.