### PR TITLE
feat(data): add "versions" attribute

### DIFF
--- a/formatPkg.js
+++ b/formatPkg.js
@@ -61,6 +61,13 @@ export default function formatPkg(pkg) {
   const devDependencies = cleaned.devDependencies || {};
   const concatenatedName = cleaned.name.replace(/[-/@_.]+/g, '');
 
+  const versions = Object.keys(cleaned.other.time)
+    .filter(key => !['modified', 'created'].includes(key))
+    .reduce((obj, key) => {
+      obj[key] = cleaned.other.time[key];
+      return obj;
+    }, {});
+
   const rawPkg = {
     objectID: cleaned.name,
     name: cleaned.name,
@@ -70,6 +77,7 @@ export default function formatPkg(pkg) {
     humanDownloadsLast30Days: numeral(0).format('0.[0]a'),
     popular: false,
     version,
+    versions,
     description: cleaned.description ? cleaned.description : null,
     dependencies,
     devDependencies,


### PR DESCRIPTION
this is available in the npm api, and shows the versions and when they were published.

Looks like

```json
{
  "versions": {
    "1.0.0": "2015-12-06T07:21:44.323Z",
    "6.4.4": "2016-01-18T02:12:56.318Z",
    "6.6.5": "2016-03-06T05:38:52.075Z",
    "6.7.4": "2016-03-23T19:08:45.951Z",
    "6.7.7": "2016-04-24T05:05:42.686Z",
    "6.10.3": "2016-06-19T02:54:28.902Z",
    "6.12.0": "2016-08-02T05:58:22.700Z",
    "6.13.2": "2016-08-24T06:09:43.742Z",
    "6.14.0": "2016-08-27T07:18:16.659Z",
    "6.15.0": "2016-09-01T17:18:50.335Z",
    "6.17.0": "2016-10-04T21:13:21.638Z",
    "6.18.0": "2016-10-25T05:36:01.320Z",
    "6.18.1": "2016-10-29T06:04:02.203Z",
    "6.18.2": "2016-11-07T00:00:41.776Z",
    "6.19.0": "2016-11-17T18:51:32.158Z",
    "6.21.0": "2016-12-19T06:02:13.385Z",
    "6.21.1-0": "2016-12-19T06:30:12.429Z",
    "6.21.1": "2017-01-03T04:06:15.964Z",
    "6.22.1": "2017-01-24T19:11:55.667Z",
    "6.23.1": "2017-02-15T05:40:51.101Z",
    "6.24.0": "2017-03-27T01:46:22.348Z"
  }
}
```