### PR TITLE
feat(process): redo bootstrap after X amount of time

### DIFF
--- a/config.js
+++ b/config.js
@@ -8,7 +8,7 @@ const defaultConfig = {
   indexName: 'npm-search',
   replicateConcurrency: 10,
   bootstrapConcurrency: 100,
-  timeToRedoBootstrap: 604800000 /* one week */,
+  timeToRedoBootstrap: 7 * 24 * 3600 * 1000 /* one week */,
   seq: null,
   indexSettings: {
     searchableAttributes: [

--- a/config.js
+++ b/config.js
@@ -8,6 +8,7 @@ const defaultConfig = {
   indexName: 'npm-search',
   replicateConcurrency: 10,
   bootstrapConcurrency: 100,
+  timeToRedoBootstrap: 604800000 /* one week */,
   seq: null,
   indexSettings: {
     searchableAttributes: [
@@ -20,7 +21,6 @@ const defaultConfig = {
       'owners.name',
     ],
     attributesForFaceting: [
-      'onlyFilter(name)' /* to be removed when frontend concatenates */,
       'onlyFilter(concatenatedName)' /* optionalFacetFilters to boost the name */,
       'keywords',
     ],

--- a/index.js
+++ b/index.js
@@ -184,6 +184,9 @@ function watch({ seq }) {
         .then(({ bootstrapLastDone }) => {
           const now = Date.now();
           const lastBootstrapped = new Date(bootstrapLastDone);
+          // when the process is running longer than a certain time
+          // we want to start over and get all info again
+          // we do this by exiting and letting Heroku start over
           if (now - lastBootstrapped > c.timeToRedoBootstrap) {
             stateManager.set({
               seq: 0,

--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ function bootstrap(state) {
           log.info('⛷ Bootstrap: done');
           return stateManager.save({
             bootstrapDone: true,
-            bootstrapLastDone: new Date().toISOString(),
+            bootstrapLastDone: new Date(),
           });
         }
 

--- a/index.js
+++ b/index.js
@@ -188,6 +188,8 @@ function watch({ seq }) {
             stateManager.set({
               seq: 0,
               bootstrapDone: false,
+            }).then(() => {
+              process.exit(0);
             });
           }
         })

--- a/index.js
+++ b/index.js
@@ -104,6 +104,7 @@ function bootstrap(state) {
           log.info('⛷ Bootstrap: done');
           return stateManager.save({
             bootstrapDone: true,
+            bootstrapLastDone: new Date().toISOString(),
           });
         }
 
@@ -179,6 +180,17 @@ function watch({ seq }) {
             seq: change.seq,
           })
         )
+        .then(stateManager.get)
+        .then(({ bootstrapLastDone }) => {
+          const now = new Date();
+          const lastBootstrapped = new Date(bootstrapLastDone);
+          if (now - lastBootstrapped > c.timeToRedoBootstrap) {
+            stateManager.set({
+              seq: 0,
+              bootstrapDone: false,
+            });
+          }
+        })
         .catch(reject);
     });
     changes.on('error', reject);

--- a/index.js
+++ b/index.js
@@ -42,8 +42,7 @@ function infoChange(seq, nbChanges, emoji) {
       Math.round(ratePerSecond),
       ms(remaining)
     );
-    loopStart = 
-      .now();
+    loopStart = Date.now();
   });
 }
 

--- a/index.js
+++ b/index.js
@@ -42,7 +42,8 @@ function infoChange(seq, nbChanges, emoji) {
       Math.round(ratePerSecond),
       ms(remaining)
     );
-    loopStart = Date.now();
+    loopStart = 
+      .now();
   });
 }
 
@@ -104,7 +105,7 @@ function bootstrap(state) {
           log.info('⛷ Bootstrap: done');
           return stateManager.save({
             bootstrapDone: true,
-            bootstrapLastDone: new Date(),
+            bootstrapLastDone: Date.now(),
           });
         }
 
@@ -182,7 +183,7 @@ function watch({ seq }) {
         )
         .then(stateManager.get)
         .then(({ bootstrapLastDone }) => {
-          const now = new Date();
+          const now = Date.now();
           const lastBootstrapped = new Date(bootstrapLastDone);
           if (now - lastBootstrapped > c.timeToRedoBootstrap) {
             stateManager.set({


### PR DESCRIPTION
fixes #20

In the 'watch' step, I get the state after each iteration, then if now - last time bootstrap was done is more than the time to redo the bootstrap, the settings

```js
stateManager.set({
  seq: 0,
  bootstrapDone: false,
});
```

are being set, which *should* make the bootstrap start over.

I am not very sure how to test this locally without having to wait a long time...