### PR TITLE
feat(pkg): add 'extra keywords' entry

### DIFF
--- a/formatPkg.js
+++ b/formatPkg.js
@@ -159,15 +159,18 @@ function getVersions(cleaned) {
 }
 
 function getKeywords(cleaned) {
+  const extraKeywords = cleaned.name.startsWith('create-')
+    ? ['yarn-create']
+    : [];
   if (cleaned.keywords) {
     if (Array.isArray(cleaned.keywords)) {
-      return [...cleaned.keywords];
+      return [...cleaned.keywords, ...extraKeywords];
     }
     if (typeof cleaned.keywords === 'string') {
-      return [cleaned.keywords];
+      return [cleaned.keywords, ...extraKeywords];
     }
   }
-  return [];
+  return [...extraKeywords];
 }
 
 function getGitHubRepoInfo(repository) {


### PR DESCRIPTION
This is initially used to add a `yarn-create` keyword to packages that start with `create-` (like create-react-app, create-next-app, create-react-native-app etc.) These packages will be available on the yarn docs page about `yarn create`, so an extra keyword like this to filter is useful.

cc @cpojer