### PR TITLE
feat(relevancy): add deprecated in account when sorting

### DIFF
--- a/config.js
+++ b/config.js
@@ -40,6 +40,7 @@ const defaultConfig = {
       'words',
       'proximity',
       'attribute',
+      'asc(deprecated)',
       'desc(popular)',
       'exact',
       'custom',


### PR DESCRIPTION
Sorting booleans asc/desc is a bit confusing, but the opposite of popular makes sense, since you want popular first, and descending as late as possible