### PR TITLE
fix(memory): don't keep a reference of the `chain` in watch

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,8 +160,6 @@ function watch({ seq }) {
     '🛰 Watch: 👍 We are in sync (or almost). Will now be 🔭 watching for registry updates'
   );
 
-  let chain = Promise.resolve();
-
   return new Promise((resolve, reject) => {
     const changes = db.changes({
       ...defaultOptions,
@@ -171,7 +169,7 @@ function watch({ seq }) {
     });
 
     changes.on('change', change => {
-      chain = chain
+      Promise.resolve()
         .then(() => saveDocs([change]), reject)
         .then(() => infoChange(change.seq, 1, '🛰'))
         .then(() =>


### PR DESCRIPTION
Reading up on promises and memory leaks, this might be the cause of our leak in the watch phase.

I'm not convinced that this is completely the same or that it will help, but we will see fast.