### PR TITLE
fix(changelog): fall back to master if the gitHead is undefined

### DIFF
--- a/formatPkg.js
+++ b/formatPkg.js
@@ -143,7 +143,7 @@ function getGitHead(pkg, version) {
   if (pkg.versions && pkg.versions[version] && pkg.versions[version].gitHead) {
     return pkg.versions[version].gitHead;
   }
-  return null;
+  return 'master';
 }
 
 function getVersions(cleaned) {

--- a/github.js
+++ b/github.js
@@ -1,14 +1,7 @@
 import got from 'got';
 import race from 'promise-rat-race';
 
-function getChangelog({
-  githubRepo = {
-    user: '',
-    project: '',
-    path: '',
-  },
-  gitHead = 'master',
-}) {
+function getChangelog({ githubRepo, gitHead }) {
   if (githubRepo === null) {
     return { changelogFilename: null };
   }


### PR DESCRIPTION
This happens from time to time for no particular reason, and in that case, we need to use 'master' as a fallback