### PR TITLE
feat(quality): add a flag for very low quality packages

### DIFF
--- a/config.js
+++ b/config.js
@@ -41,6 +41,7 @@ const defaultConfig = {
       'proximity',
       'attribute',
       'asc(deprecated)',
+      'asc(badPackage)',
       'desc(popular)',
       'exact',
       'custom',

--- a/formatPkg.js
+++ b/formatPkg.js
@@ -34,6 +34,7 @@ export default function formatPkg(pkg) {
   }
 
   const owner = getOwner(githubRepo, lastPublisher, author); // always favor the GitHub owner
+  const badPackage = isBadPackage(owner);
   const keywords = getKeywords(cleaned);
 
   const dependencies = cleaned.dependencies || {};
@@ -61,6 +62,7 @@ export default function formatPkg(pkg) {
     readme: pkg.readme,
     owner,
     deprecated: cleaned.deprecated !== undefined ? cleaned.deprecated : false,
+    badPackage,
     homepage: getHomePage(cleaned.homepage, cleaned.repository),
     license,
     keywords,
@@ -78,6 +80,16 @@ export default function formatPkg(pkg) {
   }
 
   return traverse(rawPkg).forEach(maybeEscape);
+}
+
+function isBadPackage(owner) {
+  // the organisations `npmtest` and `npmdoc` are just republishing everything
+  // this is a total mess, and shouldn't ever be used, because it makes results
+  // messy. We're ignoring packages by those "authors"
+  if (owner === 'npmdoc' || owner === 'npmtest') {
+    return true;
+  }
+  return false;
 }
 
 function maybeEscape(node) {


### PR DESCRIPTION
This is used as a custom ranking, which acts much like the `deprecated` flag, in a way that it prefers packages with `false` as the value for `badPackage`. The organisations/owners that I chose to give a lower ranking are:

- [npmtest](https://yarnpkg.com/en/packages?q=npmtest-a&p=1)
- [npmdoc](https://yarnpkg.com/en/packages?q=npmdoc-a&p=1)

These authors are just duplicating packages in a way that provides no value alltogether.