### PR TITLE
feat(schema): move git head into githubRepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ For every single NPM package, we create a record in the Algolia index. The resul
   "githubRepo": {
     "user": "babel",
     "project": "babel",
-    "path": "/tree/master/packages/babel-core"
+    "path": "/tree/master/packages/babel-core",
+    "head": "f6ad789eba27db50d25cc7eac062bbb0dde19c16"
   },
   "readme": "# babel-core\n> Babel compiler core.\n```javascript\nvar babel = require(\"babel-core\");\nimport { transform } from 'babel-core';\nimport * as babel from 'babel-core';\n```\nAll transformations will use your local configuration files (.babelrc or in package.json). See [options](#options) to disable it.\n## babel.transform(code: string, [options?](#options): Object)\nTransforms the passed in `code`. Returning an object with the generated code,\nsource map, and AST.\n```js\nbabel.transform(code, options)", //truncated at 200kb with **TRUNCATED**
   "owner": {

--- a/formatPkg.js
+++ b/formatPkg.js
@@ -16,9 +16,6 @@ export default function formatPkg(pkg) {
     return undefined;
   }
 
-  const githubRepo = cleaned.repository
-    ? getGitHubRepoInfo(cleaned.repository)
-    : null;
   const lastPublisher = cleaned.lastPublisher
     ? formatUser(cleaned.lastPublisher)
     : null;
@@ -26,8 +23,10 @@ export default function formatPkg(pkg) {
   const license = getLicense(cleaned);
 
   const version = cleaned.version ? cleaned.version : '0.0.0';
-
-  const gitHead = getGitHead(pkg, version);
+  const versions = getVersions(cleaned);
+  const githubRepo = cleaned.repository
+    ? getGitHubRepoInfo({ repository: cleaned.repository, versions, version })
+    : null;
 
   if (!githubRepo && !lastPublisher && !author) {
     return undefined; // ignore this package, we cannot link it to anyone
@@ -39,8 +38,6 @@ export default function formatPkg(pkg) {
   const dependencies = cleaned.dependencies || {};
   const devDependencies = cleaned.devDependencies || {};
   const concatenatedName = cleaned.name.replace(/[-/@_.]+/g, '');
-
-  const versions = getVersions(cleaned);
 
   const rawPkg = {
     objectID: cleaned.name,
@@ -57,7 +54,6 @@ export default function formatPkg(pkg) {
     devDependencies,
     originalAuthor: cleaned.author,
     githubRepo,
-    gitHead,
     readme: pkg.readme,
     owner,
     deprecated: cleaned.deprecated !== undefined ? cleaned.deprecated : false,
@@ -139,13 +135,6 @@ function getGravatar(obj) {
   return gravatarUrl(obj.email);
 }
 
-function getGitHead(pkg, version) {
-  if (pkg.versions && pkg.versions[version] && pkg.versions[version].gitHead) {
-    return pkg.versions[version].gitHead;
-  }
-  return 'master';
-}
-
 function getVersions(cleaned) {
   if (cleaned.other && cleaned.other.time) {
     return Object.keys(cleaned.other.time)
@@ -170,7 +159,14 @@ function getKeywords(cleaned) {
   return [];
 }
 
-function getGitHubRepoInfo(repository) {
+function getGitHead({ versions, version }) {
+  if (versions[version] && versions[version].gitHead) {
+    return versions[version].gitHead;
+  }
+  return 'master';
+}
+
+function getGitHubRepoInfo({ repository, versions, version }) {
   if (!repository || typeof repository !== 'string') return null;
 
   const result = repository.match(
@@ -185,10 +181,13 @@ function getGitHubRepoInfo(repository) {
     return null;
   }
 
+  const head = getGitHead({ versions, version });
+
   return {
     user: result[1],
     project: result[2],
     path: result[3] || '',
+    head,
   };
 }
 

--- a/formatPkg.js
+++ b/formatPkg.js
@@ -54,6 +54,7 @@ export default function formatPkg(pkg) {
     devDependencies,
     originalAuthor: cleaned.author,
     githubRepo,
+    gitHead: githubRepo.head, // remove this when we update to the new schema frontend
     readme: pkg.readme,
     owner,
     deprecated: cleaned.deprecated !== undefined ? cleaned.deprecated : false,

--- a/github.js
+++ b/github.js
@@ -1,17 +1,17 @@
 import got from 'got';
 import race from 'promise-rat-race';
 
-function getChangelog({ githubRepo, gitHead }) {
+function getChangelog(githubRepo) {
   if (githubRepo === null) {
     return { changelogFilename: null };
   }
 
-  const { user, project, path } = githubRepo;
+  const { user, project, path, head } = githubRepo;
   if (user.length < 1 || project.length < 1) {
     return { changelogFilename: null };
   }
 
-  const baseGithubURL = `https://raw.githubusercontent.com/${user}/${project}/${gitHead}/${`${path.replace('/tree/', '')}`}`;
+  const baseGithubURL = `https://raw.githubusercontent.com/${user}/${project}/${head}/${`${path.replace('/tree/', '')}`}`;
   const files = [
     'CHANGELOG.md',
     'ChangeLog.md',


### PR DESCRIPTION
This is cleaner as a structure. 

It's implemented backwards-compatible, and thus won't break the frontend, it should be fairly simple to migrate to this new structure once it's reindexed, and then we can remove the `gitHead` entry here.

In fact, I did this change on the website already, I only need to open the PR of [the branch](https://github.com/algolia/yarnpkg-website/tree/fix/move-head) once it's cleared here