### PR TITLE
feat(tags): add `tags` to the schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ For every single NPM package, we create a record in the Algolia index. The resul
   "humanDownloadsLast30Days": "7.7m",
   "popular": true,
   "version": "6.24.0",
+  "versions": {
+    "4.0.1": "2015-02-15T14:15:48.555Z",
+    "4.0.2": "2015-02-17T02:14:19.635Z",
+    "4.1.1": "2015-02-17T13:05:27.250Z",
+    "4.2.0": "2015-02-18T00:32:53.715Z",
+    [...]
+  },
+  "tags": {"latest":"6.25.0","old":"5.8.38","next":"7.0.0-alpha.19"},
   "description": "Babel compiler core.",
   "dependencies": {
     "babel-code-frame": "^6.22.0",

--- a/formatPkg.js
+++ b/formatPkg.js
@@ -42,6 +42,8 @@ export default function formatPkg(pkg) {
 
   const versions = getVersions(cleaned);
 
+  const tags = pkg['dist-tags'];
+
   const rawPkg = {
     objectID: cleaned.name,
     name: cleaned.name,
@@ -52,6 +54,7 @@ export default function formatPkg(pkg) {
     popular: false,
     version,
     versions,
+    tags,
     description: cleaned.description ? cleaned.description : null,
     dependencies,
     devDependencies,


### PR DESCRIPTION
This is useful for when you have multiple tags (latest, beta, next, RC).

I want to show this on the Yarn website, so it needs to be in the index