### PR TITLE
chore(optionalFilter): rename onlyFilter to filterOnly

### DIFF
--- a/config.js
+++ b/config.js
@@ -21,7 +21,7 @@ const defaultConfig = {
       'owners.name',
     ],
     attributesForFaceting: [
-      'onlyFilter(concatenatedName)' /* optionalFacetFilters to boost the name */,
+      'filterOnly(concatenatedName)' /* optionalFacetFilters to boost the name */,
       'searchable(keywords)',
       'searchable(owner.name)',
     ],


### PR DESCRIPTION
This was changed when OFF became OF. As reported by @pixelastic.

I'm not really sure how this will impact the search, but I think it'll be transparent