### PR TITLE
feat(babel): add a forced keyword to babel plugins

### DIFF
--- a/src/__tests__/formatPkg.test.js
+++ b/src/__tests__/formatPkg.test.js
@@ -31,6 +31,23 @@ it('truncates long readmes', () => {
   expect(formatted).toMatchSnapshot();
 });
 
+describe('adds babel plugins', () => {
+  const dogs = {
+    name: '@babel/plugin-dogs',
+    lastPublisher: { name: 'xtuc' },
+  };
+  const unofficialDogs = {
+    name: 'babel-plugin-dogs',
+    lastPublisher: { name: 'unknown' },
+  };
+
+  const formattedDogs = formatPkg(dogs);
+  const formattedUnofficialDogs = formatPkg(unofficialDogs);
+
+  expect(formattedDogs.keywords).toEqual(['babel-plugin']);
+  expect(formattedUnofficialDogs.keywords).toEqual(['babel-plugin']);
+});
+
 describe('test getRepositoryInfo', () => {
   const getRepositoryInfo = formatPkg.__RewireAPI__.__get__(
     'getRepositoryInfo'

--- a/src/formatPkg.js
+++ b/src/formatPkg.js
@@ -210,15 +210,21 @@ function getVersions(cleaned) {
 }
 
 function getKeywords(cleaned) {
+  const babelPlugins =
+    cleaned.name.startsWith('@babel/plugin') ||
+    cleaned.name.startsWith('babel-plugin-')
+      ? ['babel-plugin']
+      : [];
+
   if (cleaned.keywords) {
     if (Array.isArray(cleaned.keywords)) {
-      return [...cleaned.keywords];
+      return [...cleaned.keywords, ...babelPlugins];
     }
     if (typeof cleaned.keywords === 'string') {
-      return [cleaned.keywords];
+      return [cleaned.keywords, ...babelPlugins];
     }
   }
-  return [];
+  return [...babelPlugins];
 }
 
 function getGitHubRepoInfo({ repository, gitHead = 'master' }) {


### PR DESCRIPTION
This is useful for the babel repl which will be visible [here](https://deploy-preview-1518--babel.netlify.com/repl) + https://github.com/babel/website/pull/1518 (Yarn search change isn't visible yet, but live coded it with @xtuc)

Not all packages have a keyword, but to be installable they start with `babel-plugin-` or `@babel/plugin`