### PR TITLE
feat(vue-cli): add a forced keyword to vue-cli plugins 

### DIFF
--- a/src/__tests__/formatPkg.test.js
+++ b/src/__tests__/formatPkg.test.js
@@ -48,6 +48,29 @@ describe('adds babel plugins', () => {
   expect(formattedUnofficialDogs.keywords).toEqual(['babel-plugin']);
 });
 
+describe('adds vue-cli plugins', () => {
+  const dogs = {
+    name: '@vue/cli-plugin-dogs',
+    lastPublisher: { name: 'xtuc' },
+  };
+  const unofficialDogs = {
+    name: 'vue-cli-plugin-dogs',
+    lastPublisher: { name: 'unknown' },
+  };
+  const scopedDogs = {
+    name: '@dogs/vue-cli-plugin-dogs',
+    lastPublisher: { name: 'unknown' },
+  };
+
+  const formattedDogs = formatPkg(dogs);
+  const formattedUnofficialDogs = formatPkg(unofficialDogs);
+  const formattedScopedDogs = formatPkg(scopedDogs);
+
+  expect(formattedDogs.keywords).toEqual(['vue-cli-plugin']);
+  expect(formattedUnofficialDogs.keywords).toEqual(['vue-cli-plugin']);
+  expect(formattedScopedDogs.keywords).toEqual(['vue-cli-plugin']);
+});
+
 describe('test getRepositoryInfo', () => {
   const getRepositoryInfo = formatPkg.__RewireAPI__.__get__(
     'getRepositoryInfo'

--- a/src/formatPkg.js
+++ b/src/formatPkg.js
@@ -209,28 +209,31 @@ function getVersions(cleaned) {
   return {};
 }
 
-function getKeywords(cleaned) {
-  const babelPlugins =
-    cleaned.name.startsWith('@babel/plugin') ||
-    cleaned.name.startsWith('babel-plugin-')
-      ? ['babel-plugin']
-      : [];
+const forcedKeywords = {
+  'babel-plugin': ({ name }) =>
+    name.startsWith('@babel/plugin') || name.startsWith('babel-plugin-'),
+  'vue-cli-plugin': ({ name }) =>
+    /^(@vue\/|vue-|@[\w-]+\/vue-)cli-plugin-/.test(name),
+};
 
-  const vueCliPlugins = /^(@vue\/|vue-|@[\w-]+\/vue-)cli-plugin-/.test(
-    cleaned.name
-  )
-    ? ['vue-cli-plugin']
-    : [];
+function getKeywords(cleaned) {
+  // Forced keywords
+  const keywords = [];
+  for (const keyword in forcedKeywords) {
+    if (forcedKeywords[keyword](cleaned)) {
+      keywords.push(keyword);
+    }
+  }
 
   if (cleaned.keywords) {
     if (Array.isArray(cleaned.keywords)) {
-      return [...cleaned.keywords, ...babelPlugins, ...vueCliPlugins];
+      return [...cleaned.keywords, ...keywords];
     }
     if (typeof cleaned.keywords === 'string') {
-      return [cleaned.keywords, ...babelPlugins, ...vueCliPlugins];
+      return [cleaned.keywords, ...keywords];
     }
   }
-  return [...babelPlugins, ...vueCliPlugins];
+  return [...keywords];
 }
 
 function getGitHubRepoInfo({ repository, gitHead = 'master' }) {

--- a/src/formatPkg.js
+++ b/src/formatPkg.js
@@ -216,15 +216,21 @@ function getKeywords(cleaned) {
       ? ['babel-plugin']
       : [];
 
+  const vueCliPlugins = /^(@vue\/|vue-|@[\w-]+\/vue-)cli-plugin-/.test(
+    cleaned.name
+  )
+    ? ['vue-cli-plugin']
+    : [];
+
   if (cleaned.keywords) {
     if (Array.isArray(cleaned.keywords)) {
-      return [...cleaned.keywords, ...babelPlugins];
+      return [...cleaned.keywords, ...babelPlugins, ...vueCliPlugins];
     }
     if (typeof cleaned.keywords === 'string') {
-      return [cleaned.keywords, ...babelPlugins];
+      return [cleaned.keywords, ...babelPlugins, ...vueCliPlugins];
     }
   }
-  return [...babelPlugins];
+  return [...babelPlugins, ...vueCliPlugins];
 }
 
 function getGitHubRepoInfo({ repository, gitHead = 'master' }) {


### PR DESCRIPTION
This will be useful for the [vue-cli ui](https://github.com/vuejs/vue-cli/blob/da0d37ece4bc26c1e89d01a9b49f8f01953aa2bd/packages/%40vue/cli-ui/src/views/ProjectPluginsAdd.vue#L17).

Installable vue-cli plugins must either start with `@vue/cli-plugin` or `vue-cli-plugin` (can be scoped: `@foo/vue-cli-plugin-xxx`).