### PR TITLE
fix(timeouts): increase pouch timeout

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,11 @@ import queue from 'async/queue';
 
 log.info('🗿 npm ↔️ Algolia replication starts ⛷ 🐌 🛰');
 
-const db = new PouchDB(c.npmRegistryEndpoint);
+const db = new PouchDB(c.npmRegistryEndpoint, {
+  ajax: {
+    timeout: 30000, // default is 10s, but we have higher timeouts regularly
+  },
+});
 const defaultOptions = {
   include_docs: true, // eslint-disable-line camelcase
   conflicts: false,


### PR DESCRIPTION
We are regularly hitting the default 10s timeout when replicating.

Not exactly sure how to test that this is working more than seeing less shutdowns regarding this.

Most recent logs of a crash because of a socket timeout are:

```
Apr 02 00:55:09 npm-search app/worker.1:  { Error: ESOCKETTIMEDOUT
Apr 02 03:49:15 npm-search app/worker.1:  { Error: ESOCKETTIMEDOUT
Apr 02 07:13:01 npm-search app/worker.1:  { Error: ESOCKETTIMEDOUT
Apr 02 07:46:24 npm-search app/worker.1:  { Error: ESOCKETTIMEDOUT
Apr 02 13:00:42 npm-search app/worker.1:  { Error: ESOCKETTIMEDOUT
Apr 03 06:22:59 npm-search app/worker.1:  { Error: ESOCKETTIMEDOUT
Apr 03 08:06:23 npm-search app/worker.1:  { Error: ESOCKETTIMEDOUT
Apr 03 08:32:53 npm-search app/worker.1:  { Error: ESOCKETTIMEDOUT
Apr 03 09:54:51 npm-search app/worker.1:  { Error: ESOCKETTIMEDOUT
Apr 03 10:38:25 npm-search app/worker.1:  { Error: ESOCKETTIMEDOUT
Apr 03 12:16:37 npm-search app/worker.1:  { Error: ESOCKETTIMEDOUT
Apr 03 13:42:36 npm-search app/worker.1:  { Error: ESOCKETTIMEDOUT
Apr 03 13:43:38 npm-search app/worker.1:  { Error: ESOCKETTIMEDOUT
Apr 03 16:29:18 npm-search app/worker.1:  { Error: ESOCKETTIMEDOUT
Apr 03 18:12:37 npm-search app/worker.1:  { Error: ESOCKETTIMEDOUT
Apr 04 05:38:03 npm-search app/worker.1:  { Error: ESOCKETTIMEDOUT
Apr 04 07:58:01 npm-search app/worker.1:  { Error: ESOCKETTIMEDOUT
Apr 04 10:10:08 npm-search app/worker.1:  { Error: ESOCKETTIMEDOUT
Apr 04 14:47:01 npm-search app/worker.1:  { Error: ESOCKETTIMEDOUT
Apr 04 14:47:57 npm-search app/worker.1:  { Error: ESOCKETTIMEDOUT
Apr 04 15:29:08 npm-search app/worker.1:  { Error: ESOCKETTIMEDOUT
Apr 04 15:48:59 npm-search app/worker.1:  { Error: ESOCKETTIMEDOUT
Apr 04 18:40:37 npm-search app/worker.1:  { Error: ESOCKETTIMEDOUT
Apr 05 04:45:45 npm-search app/worker.1:  { Error: ESOCKETTIMEDOUT
Apr 05 07:03:27 npm-search app/worker.1:  { Error: ESOCKETTIMEDOUT
Apr 05 07:04:30 npm-search app/worker.1:  { Error: ESOCKETTIMEDOUT
Apr 05 12:06:39 npm-search app/worker.1:  { Error: ESOCKETTIMEDOUT
Apr 05 12:15:13 npm-search app/worker.1:  { Error: ESOCKETTIMEDOUT
```

(just put as a reference)

see https://pouchdb.com/api.html#create_database