### PR TITLE
chore(keywords): disable merging of keywords and computedKeywords

### DIFF
--- a/src/__tests__/formatPkg.test.js
+++ b/src/__tests__/formatPkg.test.js
@@ -40,7 +40,7 @@ describe('adds angular cli schematics', () => {
   };
 
   const formatted = formatPkg(angularSchema);
-  expect(formatted.keywords).toEqual(['hi', 'angular-cli-schematic']);
+  expect(formatted.keywords).toEqual(['hi']);
   expect(formatted.computedKeywords).toEqual(['angular-cli-schematic']);
   expect(formatted.computedMetadata).toEqual({
     schematics: 'bli-blo',
@@ -62,8 +62,8 @@ describe('adds babel plugins', () => {
   const formattedDogs = formatPkg(dogs);
   const formattedUnofficialDogs = formatPkg(unofficialDogs);
 
-  expect(formattedDogs.keywords).toEqual(['babel', 'babel-plugin']);
-  expect(formattedUnofficialDogs.keywords).toEqual(['dogs', 'babel-plugin']);
+  expect(formattedDogs.keywords).toEqual(['babel']);
+  expect(formattedUnofficialDogs.keywords).toEqual(['dogs']);
 
   expect(formattedDogs.computedKeywords).toEqual(['babel-plugin']);
   expect(formattedUnofficialDogs.computedKeywords).toEqual(['babel-plugin']);
@@ -87,9 +87,9 @@ describe('adds vue-cli plugins', () => {
   const formattedUnofficialDogs = formatPkg(unofficialDogs);
   const formattedScopedDogs = formatPkg(scopedDogs);
 
-  expect(formattedDogs.keywords).toEqual(['vue-cli-plugin']);
-  expect(formattedUnofficialDogs.keywords).toEqual(['vue-cli-plugin']);
-  expect(formattedScopedDogs.keywords).toEqual(['vue-cli-plugin']);
+  expect(formattedDogs.keywords).toEqual([]);
+  expect(formattedUnofficialDogs.keywords).toEqual([]);
+  expect(formattedScopedDogs.keywords).toEqual([]);
 
   expect(formattedDogs.computedKeywords).toEqual(['vue-cli-plugin']);
   expect(formattedUnofficialDogs.computedKeywords).toEqual(['vue-cli-plugin']);

--- a/src/formatPkg.js
+++ b/src/formatPkg.js
@@ -54,7 +54,7 @@ export default function formatPkg(pkg) {
   const owner = getOwner(repository, lastPublisher, author); // always favor the repository owner
   const badPackage = isBadPackage(owner);
   const { computedKeywords, computedMetadata } = getComputedData(cleaned);
-  const keywords = [...getKeywords(cleaned), ...computedKeywords]; // concat with the subset for backward compat
+  const keywords = getKeywords(cleaned);
 
   const dependencies = cleaned.dependencies || {};
   const devDependencies = cleaned.devDependencies || {};


### PR DESCRIPTION
I made PRs to the babel and Vue implementations to use the `computedKeywords` key instead of the `keywords` key for filtering. Angular already used `computedKeywords` in the first place.