### PR TITLE
test(watch): Add a test:watch script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "install": "npm run build",
     "build": "babel src -d lib --ignore test.js",
     "test": "jest && eslint .",
+    "test:watch": "jest --watchAll --no-watchman",
     "format": "prettier --write *.{js,md,json}",
     "doctoc": "doctoc --notitle --maxlevel 3 README.md",
     "precommit": "lint-staged"


### PR DESCRIPTION
`yarn run test:watch` will run the tests in a live-reload mode,
suitable for TDD. Whenever a source file or test file changes, the
test are automatically re-run.

Note that because of the way jest is running all tests in parallel, it
**will** reload all the tests whenever any file change. To mitigate
that, you can press `p` when the tests are running and enter a pattern
to limit running tests to only files matching this pattern.

The command line also contains the `--no-watchman` because of an issue
on Linux where `watchman` does not correctly detect changes made to
files and trigger changes made on the wrong files. I'll be happy to
remove that later, but it is unfortunately needed for me right now.