### PR TITLE
feat(yeoman): Identify yeoman generators through computedKeywords

### DIFF
--- a/src/__tests__/formatPkg.test.js
+++ b/src/__tests__/formatPkg.test.js
@@ -96,6 +96,36 @@ describe('adds vue-cli plugins', () => {
   expect(formattedScopedDogs.computedKeywords).toEqual(['vue-cli-plugin']);
 });
 
+describe('adds yeoman generators', () => {
+  it('should add if matches the criterions', () => {
+    const dogs = {
+      name: 'generator-dogs',
+      keywords: ['yeoman-generator'],
+      lastPublisher: { name: 'unknown' },
+    };
+    const formattedDogs = formatPkg(dogs);
+    expect(formattedDogs.computedKeywords).toEqual(['generator']);
+  });
+  it('should not add if does not start with generator-', () => {
+    const dogs = {
+      name: 'foo-dogs',
+      keywords: ['yeoman-generator'],
+      lastPublisher: { name: 'unknown' },
+    };
+    const formattedDogs = formatPkg(dogs);
+    expect(formattedDogs.computedKeywords).toEqual([]);
+  });
+  it('should not add if does not contain yeoman-generator as a keyword', () => {
+    const dogs = {
+      name: 'generator-dogs',
+      keywords: ['foo'],
+      lastPublisher: { name: 'unknown' },
+    };
+    const formattedDogs = formatPkg(dogs);
+    expect(formattedDogs.computedKeywords).toEqual([]);
+  });
+});
+
 describe('test getRepositoryInfo', () => {
   const getRepositoryInfo = formatPkg.__RewireAPI__.__get__(
     'getRepositoryInfo'

--- a/src/__tests__/formatPkg.test.js
+++ b/src/__tests__/formatPkg.test.js
@@ -104,7 +104,7 @@ describe('adds yeoman generators', () => {
       lastPublisher: { name: 'unknown' },
     };
     const formattedDogs = formatPkg(dogs);
-    expect(formattedDogs.computedKeywords).toEqual(['generator']);
+    expect(formattedDogs.computedKeywords).toEqual(['yeoman-generator']);
   });
   it('should not add if does not start with generator-', () => {
     const dogs = {

--- a/src/formatPkg.js
+++ b/src/formatPkg.js
@@ -215,7 +215,7 @@ const registrySubsetRules = [
   }),
 
   ({ name, keywords = [] }) => ({
-    name: 'generator',
+    name: 'yeoman-generator',
     include:
       name.startsWith('generator-') && keywords.includes('yeoman-generator'),
   }),

--- a/src/formatPkg.js
+++ b/src/formatPkg.js
@@ -214,6 +214,12 @@ const registrySubsetRules = [
     include: /^(@vue\/|vue-|@[\w-]+\/vue-)cli-plugin-/.test(name),
   }),
 
+  ({ name, keywords = [] }) => ({
+    name: 'generator',
+    include:
+      name.startsWith('generator-') && keywords.includes('yeoman-generator'),
+  }),
+
   ({ schematics = '' }) => ({
     name: 'angular-cli-schematic',
     include: schematics.length > 0,


### PR DESCRIPTION
This follows the official rules of what is considered a yeoman
package:
- name must start with `generator-`
- `yeoman-generator` must be in the keywords

When that happens, it will add `generator` to the `computedKeywords`.