### PR TITLE
feat(relevance): put name, description and eywords on same level

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,11 +147,11 @@ We're restricting the search to use a subset of the attributes only:
 
 ##### Prefix Search
 
-Algolia provides default prefix search capabilities (matching words with only the beginning). This is disabled for the `keywords`, `owner.name` and `owners.name` attributes.
+Algolia provides default prefix search capabilities (matching words with only the beginning). This is disabled for the `owner.name` and `owners.name` attributes.
 
 ##### Typo-tolerance
 
-Algolia provides default typo-tolerance. Typo-tolerance is disabled for the `keywords` attribute.
+Algolia provides default typo-tolerance.
 
 ##### Exact Boosting
 

--- a/src/__tests__/__snapshots__/config.test.js.snap
+++ b/src/__tests__/__snapshots__/config.test.js.snap
@@ -38,18 +38,12 @@ Object {
       "desc(downloadsLast30Days)",
     ],
     "disableExactOnAttributes": Array [
-      "description",
-      "keywords",
       "owner.name",
       "owners.name",
     ],
     "disablePrefixOnAttributes": Array [
-      "keywords",
       "owner.name",
       "owners.name",
-    ],
-    "disableTypoToleranceOnAttributes": Array [
-      "keywords",
     ],
     "exactOnSingleWordQuery": "attribute",
     "optionalWords": Array [
@@ -71,10 +65,7 @@ Object {
     "replaceSynonymsInHighlight": false,
     "searchableAttributes": Array [
       "unordered(_searchInternal.popularName)",
-      "unordered(name)",
-      "unordered(_searchInternal.concatenatedName)",
-      "unordered(description)",
-      "unordered(keywords)",
+      "unordered(name), unordered(_searchInternal.concatenatedName), unordered(description), unordered(keywords)",
       "owner.name",
       "owners.name",
     ],

--- a/src/config.js
+++ b/src/config.js
@@ -17,10 +17,7 @@ const defaultConfig = {
   indexSettings: {
     searchableAttributes: [
       'unordered(_searchInternal.popularName)',
-      'unordered(name)',
-      'unordered(_searchInternal.concatenatedName)',
-      'unordered(description)',
-      'unordered(keywords)',
+      'unordered(name), unordered(_searchInternal.concatenatedName), unordered(description), unordered(keywords)',
       'owner.name',
       'owners.name',
     ],
@@ -36,14 +33,8 @@ const defaultConfig = {
       'desc(dependents)',
       'desc(downloadsLast30Days)',
     ],
-    disablePrefixOnAttributes: ['keywords', 'owner.name', 'owners.name'],
-    disableExactOnAttributes: [
-      'description',
-      'keywords',
-      'owner.name',
-      'owners.name',
-    ],
-    disableTypoToleranceOnAttributes: ['keywords'],
+    disablePrefixOnAttributes: ['owner.name', 'owners.name'],
+    disableExactOnAttributes: ['owner.name', 'owners.name'],
     exactOnSingleWordQuery: 'attribute',
     ranking: [
       'filters',


### PR DESCRIPTION
This will give significantly more relevant results (you can try it out with the index `npm-search-relevance-test` I created to test out these settings.

I had to remove the settings to disable exact and prefix from those attributes, because it otherwise clashes with errors like

```
invalid setting for disablePrefixOnAttributes, you should requests all attributes with same priority: attr1, attr2,  does not exists
```

cc @redox, since you did the original ranking decisions here :smile: