### PR TITLE
feat(relevance): add another query rule on name

### DIFF
--- a/src/__tests__/__snapshots__/config.test.js.snap
+++ b/src/__tests__/__snapshots__/config.test.js.snap
@@ -21,12 +21,28 @@ Object {
         },
       },
       "description": "promote exact matches",
+      "objectID": "promote-exact-concatenated",
+    },
+    Object {
+      "condition": Object {
+        "anchoring": "is",
+        "pattern": "{facet:name}",
+      },
+      "consequence": Object {
+        "params": Object {
+          "automaticOptionalFacetFilters": Array [
+            "_searchInternal.name",
+          ],
+        },
+      },
+      "description": "promote exact matches",
       "objectID": "promote-exact",
     },
   ],
   "indexSettings": Object {
     "attributesForFaceting": Array [
       "filterOnly(_searchInternal.concatenatedName)",
+      "filterOnly(name)",
       "searchable(keywords)",
       "searchable(computedKeywords)",
       "searchable(owner.name)",

--- a/src/config.js
+++ b/src/config.js
@@ -23,6 +23,7 @@ const defaultConfig = {
     ],
     attributesForFaceting: [
       'filterOnly(_searchInternal.concatenatedName)' /* optionalFacetFilters to boost the name */,
+      'filterOnly(name)' /* optionalFacetFilters to boost the name */,
       'searchable(keywords)',
       'searchable(computedKeywords)',
       'searchable(owner.name)',
@@ -61,7 +62,7 @@ const defaultConfig = {
   ],
   indexRules: [
     {
-      objectID: 'promote-exact',
+      objectID: 'promote-exact-concatenated',
       description: 'promote exact matches',
       condition: {
         pattern: '{facet:_searchInternal.concatenatedName}',
@@ -70,6 +71,19 @@ const defaultConfig = {
       consequence: {
         params: {
           automaticOptionalFacetFilters: ['_searchInternal.concatenatedName'],
+        },
+      },
+    },
+    {
+      objectID: 'promote-exact',
+      description: 'promote exact matches',
+      condition: {
+        pattern: '{facet:name}',
+        anchoring: 'is',
+      },
+      consequence: {
+        params: {
+          automaticOptionalFacetFilters: ['_searchInternal.name'],
         },
       },
     },


### PR DESCRIPTION
We earlier added a query rule on concatenated name to promote if that matched, but for a query like `react-native`, you still want that first.