### PR TITLE
chore(dependents): remove the data fetching

### DIFF
--- a/src/__tests__/npm.test.js
+++ b/src/__tests__/npm.test.js
@@ -16,7 +16,7 @@ describe('info()', () => {
   });
 });
 
-describe.skip('getDependents()', () => {
+describe('getDependents()', () => {
   let dependents;
   beforeAll(async () => {
     dependents = await getDependents([
@@ -41,7 +41,14 @@ describe.skip('getDependents()', () => {
     );
   });
 
-  it('has the right approximate value', () => {
+  it('has the right fake value', () => {
+    const [jest, angular, holmes] = dependents.map(pkg => pkg.dependents);
+    expect(jest).toBe(0);
+    expect(angular).toBe(0);
+    expect(holmes).toBe(0);
+  });
+
+  it.skip('has the right approximate value', () => {
     const [jest, angular, holmes] = dependents.map(pkg =>
       pkg.dependents.toString()
     );

--- a/src/__tests__/npm.test.js
+++ b/src/__tests__/npm.test.js
@@ -16,7 +16,7 @@ describe('info()', () => {
   });
 });
 
-describe('getDependents()', () => {
+describe.skip('getDependents()', () => {
   let dependents;
   beforeAll(async () => {
     dependents = await getDependents([

--- a/src/npm.js
+++ b/src/npm.js
@@ -115,31 +115,9 @@ export async function getDownloads(pkgs) {
 
 export function getDependents(pkgs) {
   return Promise.all(
-    pkgs.map(({ name }) =>
-      got(`${c.npmRegistryEndpoint}/_design/app/_view/dependedUpon`, {
-        json: true,
-        query: {
-          startkey: JSON.stringify([name]),
-          endkey: JSON.stringify([name, {}]),
-          stale: 'update_after',
-        },
-      })
-        .then(res => res.body.rows[0] || { value: 0 })
-        .then(({ value }) => ({
-          dependents: value,
-          humanDependents: numeral(value).format('0.[0]a'),
-        }))
-        .catch(error => {
-          logWarning({
-            error,
-            type: 'dependents',
-            packages: [name],
-          });
-          return {
-            dependents: 0,
-            humanDependents: '0',
-          };
-        })
-    )
+    pkgs.map(() => ({
+      dependents: 0,
+      humanDependents: '0',
+    }))
   );
 }

--- a/src/npm.js
+++ b/src/npm.js
@@ -114,6 +114,7 @@ export async function getDownloads(pkgs) {
 }
 
 export function getDependents(pkgs) {
+  // we return 0, waiting for https://github.com/npm/registry/issues/361
   return Promise.all(
     pkgs.map(() => ({
       dependents: 0,

--- a/src/saveDocs.js
+++ b/src/saveDocs.js
@@ -1,6 +1,6 @@
 import formatPkg from './formatPkg.js';
 import log from './log.js';
-import { getDownloads } from './npm.js';
+import { getDownloads, getDependents } from './npm.js';
 import { getChangelogs } from './changelog.js';
 
 export default function saveDocs({ docs, index }) {
@@ -20,17 +20,22 @@ export default function saveDocs({ docs, index }) {
 }
 
 function addMetaData(pkgs) {
-  return Promise.all([getDownloads(pkgs), getChangelogs(pkgs)]).then(
-    ([downloads, changelogs]) =>
-      pkgs.map((pkg, index) => ({
-        ...pkg,
-        ...downloads[index],
-        ...changelogs[index],
-        _searchInternal: {
-          ...pkg._searchInternal,
-          ...downloads[index]._searchInternal,
-          ...changelogs[index]._searchInternal,
-        },
-      }))
+  return Promise.all([
+    getDownloads(pkgs),
+    getDependents(pkgs),
+    getChangelogs(pkgs),
+  ]).then(([downloads, dependents, changelogs]) =>
+    pkgs.map((pkg, index) => ({
+      ...pkg,
+      ...downloads[index],
+      ...dependents[index],
+      ...changelogs[index],
+      _searchInternal: {
+        ...pkg._searchInternal,
+        ...downloads[index]._searchInternal,
+        ...dependents[index]._searchInternal,
+        ...changelogs[index]._searchInternal,
+      },
+    }))
   );
 }

--- a/src/saveDocs.js
+++ b/src/saveDocs.js
@@ -1,6 +1,6 @@
 import formatPkg from './formatPkg.js';
 import log from './log.js';
-import { getDownloads, getDependents } from './npm.js';
+import { getDownloads } from './npm.js';
 import { getChangelogs } from './changelog.js';
 
 export default function saveDocs({ docs, index }) {
@@ -20,22 +20,17 @@ export default function saveDocs({ docs, index }) {
 }
 
 function addMetaData(pkgs) {
-  return Promise.all([
-    getDownloads(pkgs),
-    getDependents(pkgs),
-    getChangelogs(pkgs),
-  ]).then(([downloads, dependents, changelogs]) =>
-    pkgs.map((pkg, index) => ({
-      ...pkg,
-      ...downloads[index],
-      ...dependents[index],
-      ...changelogs[index],
-      _searchInternal: {
-        ...pkg._searchInternal,
-        ...downloads[index]._searchInternal,
-        ...dependents[index]._searchInternal,
-        ...changelogs[index]._searchInternal,
-      },
-    }))
+  return Promise.all([getDownloads(pkgs), getChangelogs(pkgs)]).then(
+    ([downloads, changelogs]) =>
+      pkgs.map((pkg, index) => ({
+        ...pkg,
+        ...downloads[index],
+        ...changelogs[index],
+        _searchInternal: {
+          ...pkg._searchInternal,
+          ...downloads[index]._searchInternal,
+          ...changelogs[index]._searchInternal,
+        },
+      }))
   );
 }


### PR DESCRIPTION
npm is currently serving us 404 for it (see https://github.com/npm/registry/issues/361)

Removing this is the only solution for now. This will cut down the amount of logs we're doing, and will also make CI green again.

We can revert this commit at a later date when the issue is fixed on npm's side.