### PR TITLE
feat(relevance): use jsDelivr hits for ranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ For every single NPM package, we create a record in the Algolia index. The resul
   "objectID": "babel-core",
   "_searchInternal": {
     "popularName": "babel-core",
-    "downloadsMagnitude": 8
+    "downloadsMagnitude": 8,
+    "jsDelivrPopularity": 5
   }
 }
 ```

--- a/src/__tests__/__snapshots__/config.test.js.snap
+++ b/src/__tests__/__snapshots__/config.test.js.snap
@@ -34,6 +34,7 @@ Object {
     ],
     "customRanking": Array [
       "desc(_searchInternal.downloadsMagnitude)",
+      "desc(_searchInternal.jsDelivrPopularity)",
       "desc(dependents)",
       "desc(downloadsLast30Days)",
     ],

--- a/src/config.js
+++ b/src/config.js
@@ -33,6 +33,7 @@ const defaultConfig = {
     ],
     customRanking: [
       'desc(_searchInternal.downloadsMagnitude)',
+      'desc(_searchInternal.jsDelivrPopularity)',
       'desc(dependents)',
       'desc(downloadsLast30Days)',
     ],

--- a/src/jsDelivr.js
+++ b/src/jsDelivr.js
@@ -19,5 +19,16 @@ export async function loadHits() {
 }
 
 export function getHits(pkgs) {
-  return pkgs.map(({ name }) => ({ jsDelivrHits: hits.get(name) || 0 }));
+  return pkgs.map(({ name }) => {
+    const jsDelivrHits = hits.get(name) || 0;
+
+    return {
+      jsDelivrHits,
+      _searchInternal: {
+        // anything below 1000 hits/month is likely to mean that
+        // someone just made a few random requests so we count that as 0
+        jsDelivrPopularity: Math.max(jsDelivrHits.toString().length - 3, 0),
+      },
+    };
+  });
 }


### PR DESCRIPTION
Adds `jsDelivrPopularity` as an additional ranking criteria after `downloadsMagnitude`. Since jsDelivr hits have lower priority than npm downloads I believe this would be OK to use even without a replica (and if the results are good we could drop the idea of a replica with separate ranking completely). 