### PR TITLE
Include directory details from repository objects

### DIFF
--- a/src/__tests__/formatPkg.test.js
+++ b/src/__tests__/formatPkg.test.js
@@ -252,6 +252,18 @@ describe('test getRepositoryInfo', () => {
       url: 'git+https://bitbucket.org/2klicdev/2klic-sdk.git',
     };
 
+    const githubRepoWithDirectory = {
+      type: 'git',
+      url: 'https://github.com/facebook/react.git',
+      directory: './packages/react-dom',
+    };
+
+    const githubRepoWithPathUrlAndDirectory = {
+      type: 'git',
+      url: 'https://github.com/facebook/react/tree/master/packages/wrong',
+      directory: './packages/react-dom',
+    };
+
     expect(getRepositoryInfo(githubRepo)).toEqual({
       host: 'github.com',
       user: 'webpack',
@@ -271,6 +283,20 @@ describe('test getRepositoryInfo', () => {
       user: '2klicdev',
       project: '2klic-sdk',
       path: '',
+    });
+
+    expect(getRepositoryInfo(githubRepoWithDirectory)).toEqual({
+      host: 'github.com',
+      user: 'facebook',
+      project: 'react',
+      path: 'packages/react-dom',
+    });
+
+    expect(getRepositoryInfo(githubRepoWithPathUrlAndDirectory)).toEqual({
+      host: 'github.com',
+      user: 'facebook',
+      project: 'react',
+      path: 'packages/react-dom',
     });
   });
 

--- a/src/formatPkg.js
+++ b/src/formatPkg.js
@@ -338,6 +338,7 @@ function getRepositoryInfo(repository) {
   }
 
   const url = typeof repository === 'string' ? repository : repository.url;
+  const path = typeof repository === 'string' ? '' : repository.directory || '';
 
   if (!url) {
     return null;
@@ -354,7 +355,7 @@ function getRepositoryInfo(repository) {
       project,
       user,
       host: domain,
-      path: '',
+      path: path.replace(/^[./]+/, ''),
     };
   }
 
@@ -363,7 +364,14 @@ function getRepositoryInfo(repository) {
    *   https://github.com/babel/babel/tree/master/packages/babel-core
    * so we need to do it
    */
-  return getRepositoryInfoFromHttpUrl(url);
+  const repositoryInfoFromUrl = getRepositoryInfoFromHttpUrl(url);
+  if (!repositoryInfoFromUrl) {
+    return null;
+  }
+  return {
+    ...repositoryInfoFromUrl,
+    path: path.replace(/^[./]+/, '') || repositoryInfoFromUrl.path,
+  };
 }
 
 function formatUser(user) {


### PR DESCRIPTION
Now that https://github.com/npm/rfcs/pull/19 and https://github.com/npm/cli/pull/140 have been merged (woo! yay!) a number of packages have started specifying their directory within a monorepo as a `directory` attribute on their `repository` object. See, for example, [react-dom](http://registry.npmjs.org/react-dom/16.8.2).

This PR update the `getRepositoryInfo` logic to pull path details from this directory field, if present (and fall back to trying to pull it out of the URL). If merged, it will mean the GitHub link on pages like [this one](https://yarnpkg.com/en/package/react-dom) link to the correct folder within the react monorepo (woo! yay!).

(Credit to @ybiquitous for pointing me in the right direction on this one.)