### PR TITLE
Adds whether there are types for a package to an index

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,94 +39,94 @@ For every single NPM package, we create a record in the Algolia index. The resul
 
 ```json5
 {
-  "name": "babel-core",
-  "concatenatedName": "babelcore",
-  "downloadsLast30Days": 10978749,
-  "downloadsRatio": 0.08310651682685861,
-  "humanDownloadsLast30Days": "11m",
-  "jsDelivrHits": 11684192,
-  "popular": true,
-  "version": "6.26.0",
-  "versions": {
+  name: 'babel-core',
+  concatenatedName: 'babelcore',
+  downloadsLast30Days: 10978749,
+  downloadsRatio: 0.08310651682685861,
+  humanDownloadsLast30Days: '11m',
+  jsDelivrHits: 11684192,
+  popular: true,
+  version: '6.26.0',
+  versions: {
     // [...]
-    "7.0.0-beta.3": "2017-10-15T13:12:35.166Z"
+    '7.0.0-beta.3': '2017-10-15T13:12:35.166Z',
   },
-  "tags": {
-    "latest": "6.26.0",
-    "old": "5.8.38",
-    "next": "7.0.0-beta.3"
+  tags: {
+    latest: '6.26.0',
+    old: '5.8.38',
+    next: '7.0.0-beta.3',
   },
-  "description": "Babel compiler core.",
-  "dependencies": {
-    "babel-code-frame": "^6.26.0"
-    // [...]
-  },
-  "devDependencies": {
-    "babel-helper-fixtures": "^6.26.0"
+  description: 'Babel compiler core.',
+  dependencies: {
+    'babel-code-frame': '^6.26.0',
     // [...]
   },
-  "repository": {
-    "url": "https://github.com/babel/babel/tree/master/packages/babel-core",
-    "host": "github.com",
-    "user": "babel",
-    "project": "babel",
-    "path": "/tree/master/packages/babel-core",
-    "branch": "master"
+  devDependencies: {
+    'babel-helper-fixtures': '^6.26.0',
+    // [...]
   },
-  "readme":
-    "# babel-core\n\n> Babel compiler core.\n\n\n [... truncated at 200kb]",
-  "owner": {
+  repository: {
+    url: 'https://github.com/babel/babel/tree/master/packages/babel-core',
+    host: 'github.com',
+    user: 'babel',
+    project: 'babel',
+    path: '/tree/master/packages/babel-core',
+    branch: 'master',
+  },
+  readme: '# babel-core\n\n> Babel compiler core.\n\n\n [... truncated at 200kb]',
+  owner: {
     // either GitHub owner or npm owner
-    "name": "babel",
-    "avatar": "https://github.com/babel.png",
-    "link": "https://github.com/babel"
+    name: 'babel',
+    avatar: 'https://github.com/babel.png',
+    link: 'https://github.com/babel',
   },
-  "deprecated": false,
-  "badPackage": false,
-  "homepage": "https://babeljs.io/",
-  "license": "MIT",
-  "keywords": [
-    "6to5",
-    "babel",
-    "classes",
-    "const",
-    "es6",
-    "harmony",
-    "let",
-    "modules",
-    "transpile",
-    "transpiler",
-    "var",
-    "babel-core",
-    "compiler"
+  deprecated: false,
+  badPackage: false,
+  homepage: 'https://babeljs.io/',
+  license: 'MIT',
+  keywords: [
+    '6to5',
+    'babel',
+    'classes',
+    'const',
+    'es6',
+    'harmony',
+    'let',
+    'modules',
+    'transpile',
+    'transpiler',
+    'var',
+    'babel-core',
+    'compiler',
   ],
-  "created": 1424009748555,
-  "modified": 1508833762239,
-  "lastPublisher": {
-    "name": "hzoo",
-    "email": "hi@henryzoo.com",
-    "avatar": "https://gravatar.com/avatar/851fb4fa7ca479bce1ae0cdf80d6e042",
-    "link": "https://www.npmjs.com/~hzoo"
+  created: 1424009748555,
+  modified: 1508833762239,
+  lastPublisher: {
+    name: 'hzoo',
+    email: 'hi@henryzoo.com',
+    avatar: 'https://gravatar.com/avatar/851fb4fa7ca479bce1ae0cdf80d6e042',
+    link: 'https://www.npmjs.com/~hzoo',
   },
-  "owners": [
+  owners: [
     {
-      "email": "me@thejameskyle.com",
-      "name": "thejameskyle",
-      "avatar": "https://gravatar.com/avatar/8a00efb48d632ae449794c094f7d5c38",
-      "link": "https://www.npmjs.com/~thejameskyle"
-    }
+      email: 'me@thejameskyle.com',
+      name: 'thejameskyle',
+      avatar: 'https://gravatar.com/avatar/8a00efb48d632ae449794c094f7d5c38',
+      link: 'https://www.npmjs.com/~thejameskyle',
+    },
     // [...]
   ],
-  "lastCrawl": "2017-10-24T08:29:24.672Z",
-  "dependents": 3321,
-  "humanDependents": "3.3k",
-  "changelogFilename": null, // if babel-core had a changelog, it would be the raw GitHub url here
-  "objectID": "babel-core",
-  "_searchInternal": {
-    "popularName": "babel-core",
-    "downloadsMagnitude": 8,
-    "jsDelivrPopularity": 5
-  }
+  lastCrawl: '2017-10-24T08:29:24.672Z',
+  dependents: 3321,
+  ts: undefined,
+  humanDependents: '3.3k',
+  changelogFilename: null, // if babel-core had a changelog, it would be the raw GitHub url here
+  objectID: 'babel-core',
+  _searchInternal: {
+    popularName: 'babel-core',
+    downloadsMagnitude: 8,
+    jsDelivrPopularity: 5,
+  },
 }
 ```
 
@@ -182,7 +182,7 @@ apiKey=... yarn start
 
 ### Restart
 
-To restart from a particular point (or from the begining):
+To restart from a particular point (or from the beginning):
 
 ```sh
 seq=0 apiKey=... yarn start

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ For every single NPM package, we create a record in the Algolia index. The resul
   ],
   lastCrawl: '2017-10-24T08:29:24.672Z',
   dependents: 3321,
-  ts: undefined,
+  types: { ts: '@types/babel-core' },
   humanDependents: '3.3k',
   changelogFilename: null, // if babel-core had a changelog, it would be the raw GitHub url here
   objectID: 'babel-core',

--- a/src/__tests__/__snapshots__/config.test.js.snap
+++ b/src/__tests__/__snapshots__/config.test.js.snap
@@ -179,9 +179,11 @@ Object {
   "maxObjSize": 450000,
   "npmDownloadsEndpoint": "https://api.npmjs.org/downloads",
   "npmRegistryEndpoint": "https://replicate.npmjs.com/registry",
+  "npmRootEndpoint": "https://api.npmjs.org/",
   "popularDownloadsRatio": 0.005,
   "replicateConcurrency": 10,
   "seq": null,
   "timeToRedoBootstrap": 604800000,
+  "unpkgRoot": "https://unpkg.com/",
 }
 `;

--- a/src/__tests__/npm.test.js
+++ b/src/__tests__/npm.test.js
@@ -117,7 +117,7 @@ describe('getDownloads()', () => {
     );
 
     // eslint-disable-next-line no-console
-    // console.log('downloads', { jest, angular, holmes });
+    console.log('downloads', { jest, angular, holmes });
 
     expect(jest.length).toBeGreaterThanOrEqual(6);
     expect(jest.length).toBeLessThanOrEqual(8);

--- a/src/__tests__/npm.test.js
+++ b/src/__tests__/npm.test.js
@@ -117,7 +117,7 @@ describe('getDownloads()', () => {
     );
 
     // eslint-disable-next-line no-console
-    console.log('downloads', { jest, angular, holmes });
+    // console.log('downloads', { jest, angular, holmes });
 
     expect(jest.length).toBeGreaterThanOrEqual(6);
     expect(jest.length).toBeLessThanOrEqual(8);

--- a/src/__tests__/typescript.test.js
+++ b/src/__tests__/typescript.test.js
@@ -1,0 +1,47 @@
+import { getTypeScriptSupport } from '../typescriptSupport';
+jest.mock('../npm');
+jest.mock('../unpkg');
+import { validatePackageExists } from '../npm';
+import { fileExistsInUnpkg } from '../unpkg.js';
+
+describe('getTypeScriptSupport()', () => {
+  it('If types or typings are present in pkg.json - return early', async () => {
+    let typesSupport = await getTypeScriptSupport({
+      name: 'Has Types',
+      types: './types',
+    });
+
+    expect(typesSupport).toEqual({ types: { ts: 'included' } });
+
+    typesSupport = await getTypeScriptSupport({
+      name: 'Has Types',
+      typings: './types',
+    });
+
+    expect(typesSupport).toEqual({ types: { ts: 'included' } });
+  });
+
+  describe('without types/typings', () => {
+    it('Checks for @types/[name]', async () => {
+      validatePackageExists.mockResolvedValue(true);
+      const atTypesSupport = await getTypeScriptSupport({ name: 'my-lib' });
+      expect(atTypesSupport).toEqual({ types: { ts: '@types/my-lib' } });
+    });
+
+    it('Checks for a d.ts resolved version of main ', async () => {
+      validatePackageExists.mockResolvedValue(false);
+      fileExistsInUnpkg.mockResolvedValue(true);
+
+      const typesSupport = await getTypeScriptSupport({ name: 'my-lib' });
+      expect(typesSupport).toEqual({ types: { ts: 'included' } });
+    });
+
+    it('Handles not having and TS types', async () => {
+      validatePackageExists.mockResolvedValue(false);
+      fileExistsInUnpkg.mockResolvedValue(false);
+
+      const typesSupport = await getTypeScriptSupport({ name: 'my-lib' });
+      expect(typesSupport).toEqual({ types: { ts: null } });
+    });
+  });
+});

--- a/src/config.js
+++ b/src/config.js
@@ -5,7 +5,9 @@ import ms from 'ms';
 const defaultConfig = {
   npmRegistryEndpoint: 'https://replicate.npmjs.com/registry',
   npmDownloadsEndpoint: 'https://api.npmjs.org/downloads',
+  npmRootEndpoint: 'https://api.npmjs.org/',
   jsDelivrHitsEndpoint: 'https://data.jsdelivr.com/v1/stats/packages/month/all',
+  unpkgRoot: 'https://unpkg.com/',
   maxObjSize: 450000,
   popularDownloadsRatio: 0.005,
   appId: 'OFCNCOG2CU',

--- a/src/npm.js
+++ b/src/npm.js
@@ -20,6 +20,13 @@ const logWarning = ({ error, type, packagesStr }) => {
   );
 };
 
+export function validatePackageExists(pkgName) {
+  return got(`${c.npmRootEndpoint}/${pkgName}`, {
+    json: true,
+    method: 'HEAD',
+  }).then(response => response.statusCode === 200);
+}
+
 export async function getDownloads(pkgs) {
   // npm has a weird API to get downloads via GET params, so we split pkgs into chunks
   // and do multiple requests to avoid weird cases when concurrency is high

--- a/src/saveDocs.js
+++ b/src/saveDocs.js
@@ -3,6 +3,7 @@ import log from './log.js';
 import { getDownloads, getDependents } from './npm.js';
 import { getChangelogs } from './changelog.js';
 import { getHits } from './jsDelivr';
+import { getTSSupport } from './typescriptSupport';
 
 export default function saveDocs({ docs, index }) {
   const rawPkgs = docs
@@ -26,13 +27,15 @@ function addMetaData(pkgs) {
     getDependents(pkgs),
     getChangelogs(pkgs),
     getHits(pkgs),
-  ]).then(([downloads, dependents, changelogs, hits]) =>
+    getTSSupport(pkgs),
+  ]).then(([downloads, dependents, changelogs, hits, ts]) =>
     pkgs.map((pkg, index) => ({
       ...pkg,
       ...downloads[index],
       ...dependents[index],
       ...changelogs[index],
       ...hits[index],
+      ...ts[index],
       _searchInternal: {
         ...pkg._searchInternal,
         ...downloads[index]._searchInternal,

--- a/src/typescriptSupport.js
+++ b/src/typescriptSupport.js
@@ -1,0 +1,46 @@
+// @ts-check
+
+import { validatePackageExists } from './npm.js';
+import { fileExistsInUnpkg } from './unpkg.js';
+
+/**
+ * Basically either
+ *  - { ts: undefined }  for no existing TypeScript support
+ *  - { ts: "@types/module" } - for definitely typed support
+ *  - { ts: "included" } - for types shipped with the module
+ * */
+export async function getTypeScriptSupportString(pkg) {
+  // The cheap and simple (+ recommended by TS) way
+  // of adding a types section to your package.json
+  if (pkg.types) {
+    return { ts: 'included' };
+  }
+
+  // Older, but still works way of defining your types
+  if (pkg.typings) {
+    return { ts: 'included' };
+  }
+
+  // The 2nd most likely is definitely typed
+  const defTypeName = `@types/${pkg.name}`;
+  const defTyped = await validatePackageExists(defTypeName);
+  if (defTyped) {
+    return { ts: defTypeName };
+  }
+
+  // Check if main's JS file can be resolved to a d.ts file instead
+  const main = pkg.main || 'index.js';
+  if (main.endsWith('.js')) {
+    const dtsMain = main.replace(/js$/, 'd.ts');
+    const resolved = await fileExistsInUnpkg(pkg.name, pkg.version, dtsMain);
+    if (resolved) {
+      return { ts: 'included' };
+    }
+  }
+
+  return { ts: undefined };
+}
+
+export function getTSSupport(pkgs) {
+  return Promise.all(pkgs.map(getTypeScriptSupportString));
+}

--- a/src/typescriptSupport.js
+++ b/src/typescriptSupport.js
@@ -5,27 +5,27 @@ import { fileExistsInUnpkg } from './unpkg.js';
 
 /**
  * Basically either
- *  - { ts: undefined }  for no existing TypeScript support
- *  - { ts: "@types/module" } - for definitely typed support
- *  - { ts: "included" } - for types shipped with the module
+ *  - { types: { ts: null }}  for no existing TypeScript support
+ *  - { types: { ts: "@types/module" }} - for definitely typed support
+ *  - { types: { ts: "included" }} - for types shipped with the module
  * */
-export async function getTypeScriptSupportString(pkg) {
+export async function getTypeScriptSupport(pkg) {
   // The cheap and simple (+ recommended by TS) way
   // of adding a types section to your package.json
   if (pkg.types) {
-    return { ts: 'included' };
+    return { types: { ts: 'included' } };
   }
 
   // Older, but still works way of defining your types
   if (pkg.typings) {
-    return { ts: 'included' };
+    return { types: { ts: 'included' } };
   }
 
   // The 2nd most likely is definitely typed
   const defTypeName = `@types/${pkg.name}`;
   const defTyped = await validatePackageExists(defTypeName);
   if (defTyped) {
-    return { ts: defTypeName };
+    return { types: { ts: defTypeName } };
   }
 
   // Check if main's JS file can be resolved to a d.ts file instead
@@ -34,13 +34,13 @@ export async function getTypeScriptSupportString(pkg) {
     const dtsMain = main.replace(/js$/, 'd.ts');
     const resolved = await fileExistsInUnpkg(pkg.name, pkg.version, dtsMain);
     if (resolved) {
-      return { ts: 'included' };
+      return { types: { ts: 'included' } };
     }
   }
 
-  return { ts: undefined };
+  return { types: { ts: null } };
 }
 
 export function getTSSupport(pkgs) {
-  return Promise.all(pkgs.map(getTypeScriptSupportString));
+  return Promise.all(pkgs.map(getTypeScriptSupport));
 }

--- a/src/unpkg.js
+++ b/src/unpkg.js
@@ -1,0 +1,14 @@
+// @ts-check
+import c from './config.js';
+import got from 'got';
+
+// make a head request to a route like:
+// https://unpkg.com/lodash@4.17.11/_LazyWrapper.js
+// to validate the existence of a particular file
+export function fileExistsInUnpkg(pkg, version, path) {
+  const uri = `${c.unpkgRoot}/${pkg}@${version}/${path}`;
+  return got(uri, {
+    json: true,
+    method: 'HEAD',
+  }).then(response => response.statusCode === 200);
+}


### PR DESCRIPTION
Based [on this](https://twitter.com/mxstbr/status/1139498444777824256) discussion. This PR adds a new field to the JSON index for npm search

```sh
{
  ...
  "types": { "ts": "included" }
}
```

or

```sh
{
  ...
  "types": { "ts": "@types/lodash" }
}
```

and if they don't support it:

```sh
{
  ...
 "types": {  "ts": null }
}
```

which might be absent in JSON? Or false. Actually not sure. But definitely falsy.

Running `yarn format` did a few more changes than I would have done solo, but I'll leave comments in here about what I've changed.

Note: I've not been able to successfully run this locally against a set of packages, so right now it's somewhat ready for testing but not guaranteed to be shippable without risk. Should work tho - hah. 

Adding comments now.