### PR TITLE
fix(TS): infer definitions correctly

### DIFF
--- a/src/__tests__/__snapshots__/config.test.js.snap
+++ b/src/__tests__/__snapshots__/config.test.js.snap
@@ -179,7 +179,7 @@ Object {
   "maxObjSize": 450000,
   "npmDownloadsEndpoint": "https://api.npmjs.org/downloads",
   "npmRegistryEndpoint": "https://replicate.npmjs.com/registry",
-  "npmRootEndpoint": "https://api.npmjs.org",
+  "npmRootEndpoint": "https://registry.npmjs.org",
   "popularDownloadsRatio": 0.005,
   "replicateConcurrency": 10,
   "seq": null,

--- a/src/__tests__/__snapshots__/formatPkg.test.js.snap
+++ b/src/__tests__/__snapshots__/formatPkg.test.js.snap
@@ -158,6 +158,7 @@ Are you in trouble? Read through our [contribution guidelines](https://bitbucket
   "tags": Object {
     "latest": "1.6.1",
   },
+  "types": undefined,
   "version": "1.6.1",
   "versions": Object {
     "1.0.0": "2017-01-29T23:47:18.021Z",
@@ -286,6 +287,7 @@ Object {
   "tags": Object {
     "latest": "0.0.4",
   },
+  "types": undefined,
   "version": "0.0.4",
   "versions": Object {
     "0.0.1": "2017-06-22T16:19:35.102Z",
@@ -401,6 +403,7 @@ Object {
   "tags": Object {
     "latest": "4.4.2",
   },
+  "types": undefined,
   "version": "4.4.2",
   "versions": Object {
     "4.4.2": "2019-04-10T11:34:01.895Z",
@@ -478,6 +481,7 @@ index(arr, obj);
   "tags": Object {
     "latest": "0.0.1",
   },
+  "types": undefined,
   "version": "0.0.1",
   "versions": Object {
     "0.0.1": "2012-08-31T16:20:14.894Z",
@@ -531,6 +535,7 @@ Object {
   "readme": Any<String>,
   "repository": null,
   "tags": undefined,
+  "types": undefined,
   "version": "0.0.0",
   "versions": Object {},
 }

--- a/src/__tests__/__snapshots__/formatPkg.test.js.snap
+++ b/src/__tests__/__snapshots__/formatPkg.test.js.snap
@@ -158,7 +158,9 @@ Are you in trouble? Read through our [contribution guidelines](https://bitbucket
   "tags": Object {
     "latest": "1.6.1",
   },
-  "types": undefined,
+  "types": Object {
+    "ts": null,
+  },
   "version": "1.6.1",
   "versions": Object {
     "1.0.0": "2017-01-29T23:47:18.021Z",
@@ -287,7 +289,9 @@ Object {
   "tags": Object {
     "latest": "0.0.4",
   },
-  "types": undefined,
+  "types": Object {
+    "ts": null,
+  },
   "version": "0.0.4",
   "versions": Object {
     "0.0.1": "2017-06-22T16:19:35.102Z",
@@ -403,7 +407,9 @@ Object {
   "tags": Object {
     "latest": "4.4.2",
   },
-  "types": undefined,
+  "types": Object {
+    "ts": null,
+  },
   "version": "4.4.2",
   "versions": Object {
     "4.4.2": "2019-04-10T11:34:01.895Z",
@@ -481,7 +487,9 @@ index(arr, obj);
   "tags": Object {
     "latest": "0.0.1",
   },
-  "types": undefined,
+  "types": Object {
+    "ts": null,
+  },
   "version": "0.0.1",
   "versions": Object {
     "0.0.1": "2012-08-31T16:20:14.894Z",
@@ -535,7 +543,9 @@ Object {
   "readme": Any<String>,
   "repository": null,
   "tags": undefined,
-  "types": undefined,
+  "types": Object {
+    "ts": null,
+  },
   "version": "0.0.0",
   "versions": Object {},
 }

--- a/src/__tests__/__snapshots__/formatPkg.test.js.snap
+++ b/src/__tests__/__snapshots__/formatPkg.test.js.snap
@@ -159,7 +159,10 @@ Are you in trouble? Read through our [contribution guidelines](https://bitbucket
     "latest": "1.6.1",
   },
   "types": Object {
-    "ts": null,
+    "ts": Object {
+      "dtsMain": "index.d.ts",
+      "possible": true,
+    },
   },
   "version": "1.6.1",
   "versions": Object {
@@ -290,7 +293,10 @@ Object {
     "latest": "0.0.4",
   },
   "types": Object {
-    "ts": null,
+    "ts": Object {
+      "dtsMain": "index.d.ts",
+      "possible": true,
+    },
   },
   "version": "0.0.4",
   "versions": Object {
@@ -408,7 +414,10 @@ Object {
     "latest": "4.4.2",
   },
   "types": Object {
-    "ts": null,
+    "ts": Object {
+      "dtsMain": "index.d.ts",
+      "possible": true,
+    },
   },
   "version": "4.4.2",
   "versions": Object {
@@ -488,7 +497,10 @@ index(arr, obj);
     "latest": "0.0.1",
   },
   "types": Object {
-    "ts": null,
+    "ts": Object {
+      "dtsMain": "index.d.ts",
+      "possible": true,
+    },
   },
   "version": "0.0.1",
   "versions": Object {
@@ -544,7 +556,10 @@ Object {
   "repository": null,
   "tags": undefined,
   "types": Object {
-    "ts": null,
+    "ts": Object {
+      "dtsMain": "index.d.ts",
+      "possible": true,
+    },
   },
   "version": "0.0.0",
   "versions": Object {},

--- a/src/__tests__/formatPkg.test.js
+++ b/src/__tests__/formatPkg.test.js
@@ -168,6 +168,24 @@ describe('adds webpack scaffolds', () => {
   });
 });
 
+it('adds types if included in the package.json', () => {
+  expect(
+    formatPkg({
+      name: 'xxx',
+      lastPublisher: { name: 'unknown' },
+      types: './test.dts',
+    })
+  ).toEqual(expect.objectContaining({ types: { ts: 'included' } }));
+
+  expect(
+    formatPkg({
+      name: 'xxx',
+      lastPublisher: { name: 'unknown' },
+      typings: './test.dts',
+    })
+  ).toEqual(expect.objectContaining({ types: { ts: 'included' } }));
+});
+
 describe('test getRepositoryInfo', () => {
   const getRepositoryInfo = formatPkg.__RewireAPI__.__get__(
     'getRepositoryInfo'

--- a/src/__tests__/formatPkg.test.js
+++ b/src/__tests__/formatPkg.test.js
@@ -168,22 +168,59 @@ describe('adds webpack scaffolds', () => {
   });
 });
 
-it('adds types if included in the package.json', () => {
-  expect(
-    formatPkg({
-      name: 'xxx',
-      lastPublisher: { name: 'unknown' },
-      types: './test.dts',
-    })
-  ).toEqual(expect.objectContaining({ types: { ts: 'included' } }));
+describe('adds TypeScript information', () => {
+  it('adds types if included in the package.json', () => {
+    expect(
+      formatPkg({
+        name: 'xxx',
+        lastPublisher: { name: 'unknown' },
+        types: './test.dts',
+      })
+    ).toEqual(expect.objectContaining({ types: { ts: 'included' } }));
 
-  expect(
-    formatPkg({
-      name: 'xxx',
-      lastPublisher: { name: 'unknown' },
-      typings: './test.dts',
-    })
-  ).toEqual(expect.objectContaining({ types: { ts: 'included' } }));
+    expect(
+      formatPkg({
+        name: 'xxx',
+        lastPublisher: { name: 'unknown' },
+        typings: './test.dts',
+      })
+    ).toEqual(expect.objectContaining({ types: { ts: 'included' } }));
+  });
+
+  it('adds types possible if we can find a main file', () => {
+    expect(
+      formatPkg({
+        name: 'xxx',
+        lastPublisher: { name: 'unknown' },
+        main: 'main.js',
+      })
+    ).toEqual(
+      expect.objectContaining({
+        types: { ts: { possible: true, dtsMain: 'main.d.ts' } },
+      })
+    );
+
+    expect(
+      formatPkg({
+        name: 'xxx',
+        lastPublisher: { name: 'unknown' },
+      })
+    ).toEqual(
+      expect.objectContaining({
+        types: { ts: { possible: true, dtsMain: 'index.d.ts' } },
+      })
+    );
+  });
+
+  it('gives up when no main is not js', () => {
+    expect(
+      formatPkg({
+        name: 'xxx',
+        main: 'shell-script.sh',
+        lastPublisher: { name: 'unknown' },
+      })
+    ).toEqual(expect.objectContaining({ types: { ts: null } }));
+  });
 });
 
 describe('test getRepositoryInfo', () => {

--- a/src/__tests__/typescript.test.js
+++ b/src/__tests__/typescript.test.js
@@ -17,7 +17,10 @@ describe('getTypeScriptSupport()', () => {
   describe('without types/typings', () => {
     it('Checks for @types/[name]', async () => {
       validatePackageExists.mockResolvedValue(true);
-      const atTypesSupport = await getTypeScriptSupport({ name: 'my-lib' });
+      const atTypesSupport = await getTypeScriptSupport({
+        name: 'my-lib',
+        types: { ts: null },
+      });
       expect(atTypesSupport).toEqual({ types: { ts: '@types/my-lib' } });
     });
 
@@ -25,7 +28,10 @@ describe('getTypeScriptSupport()', () => {
       validatePackageExists.mockResolvedValue(false);
       fileExistsInUnpkg.mockResolvedValue(true);
 
-      const typesSupport = await getTypeScriptSupport({ name: 'my-lib' });
+      const typesSupport = await getTypeScriptSupport({
+        name: 'my-lib',
+        types: { ts: null },
+      });
       expect(typesSupport).toEqual({ types: { ts: 'included' } });
     });
 
@@ -33,7 +39,10 @@ describe('getTypeScriptSupport()', () => {
       validatePackageExists.mockResolvedValue(false);
       fileExistsInUnpkg.mockResolvedValue(false);
 
-      const typesSupport = await getTypeScriptSupport({ name: 'my-lib' });
+      const typesSupport = await getTypeScriptSupport({
+        name: 'my-lib',
+        types: { ts: null },
+      });
       expect(typesSupport).toEqual({ types: { ts: null } });
     });
   });

--- a/src/__tests__/typescript.test.js
+++ b/src/__tests__/typescript.test.js
@@ -30,7 +30,7 @@ describe('getTypeScriptSupport()', () => {
 
       const typesSupport = await getTypeScriptSupport({
         name: 'my-lib',
-        types: { ts: null },
+        types: { ts: { possible: true, dtsMain: 'main.d.ts' } },
       });
       expect(typesSupport).toEqual({ types: { ts: 'included' } });
     });

--- a/src/__tests__/typescript.test.js
+++ b/src/__tests__/typescript.test.js
@@ -5,17 +5,10 @@ import { validatePackageExists } from '../npm';
 import { fileExistsInUnpkg } from '../unpkg.js';
 
 describe('getTypeScriptSupport()', () => {
-  it('If types or typings are present in pkg.json - return early', async () => {
-    let typesSupport = await getTypeScriptSupport({
+  it('If types are already calculated - return early', async () => {
+    const typesSupport = await getTypeScriptSupport({
       name: 'Has Types',
-      types: './types',
-    });
-
-    expect(typesSupport).toEqual({ types: { ts: 'included' } });
-
-    typesSupport = await getTypeScriptSupport({
-      name: 'Has Types',
-      typings: './types',
+      types: { ts: 'included' },
     });
 
     expect(typesSupport).toEqual({ types: { ts: 'included' } });

--- a/src/config.js
+++ b/src/config.js
@@ -5,7 +5,7 @@ import ms from 'ms';
 const defaultConfig = {
   npmRegistryEndpoint: 'https://replicate.npmjs.com/registry',
   npmDownloadsEndpoint: 'https://api.npmjs.org/downloads',
-  npmRootEndpoint: 'https://api.npmjs.org',
+  npmRootEndpoint: 'https://registry.npmjs.org',
   jsDelivrHitsEndpoint: 'https://data.jsdelivr.com/v1/stats/packages/month/all',
   unpkgRoot: 'https://unpkg.com',
   maxObjSize: 450000,

--- a/src/formatPkg.js
+++ b/src/formatPkg.js
@@ -51,6 +51,8 @@ export default function formatPkg(pkg) {
         }
       : null;
 
+  const types = getTypes(pkg);
+
   const owner = getOwner(repository, lastPublisher, author); // always favor the repository owner
   const { computedKeywords, computedMetadata } = getComputedData(cleaned);
   const keywords = getKeywords(cleaned);
@@ -92,6 +94,7 @@ export default function formatPkg(pkg) {
     lastPublisher,
     owners: (cleaned.owners || []).map(formatUser),
     bin: cleaned.bin,
+    types,
     lastCrawl: new Date().toISOString(),
     _searchInternal: {
       concatenatedName,
@@ -385,4 +388,17 @@ function formatUser(user) {
     avatar: getGravatar(user),
     link: `https://www.npmjs.com/~${encodeURIComponent(user.name)}`,
   };
+}
+
+function getTypes(pkg) {
+  // The cheap and simple (+ recommended by TS) way
+  // of adding a types section to your package.json
+  if (pkg.types) {
+    return { ts: 'included' };
+  }
+
+  // Older, but still works way of defining your types
+  if (pkg.typings) {
+    return { ts: 'included' };
+  }
 }

--- a/src/formatPkg.js
+++ b/src/formatPkg.js
@@ -402,5 +402,18 @@ function getTypes(pkg) {
     return { ts: 'included' };
   }
 
-  return { ts: null };
+  const main = pkg.main || 'index.js';
+  if (main.endsWith('.js')) {
+    const dtsMain = main.replace(/js$/, 'd.ts');
+    return {
+      ts: {
+        possible: true,
+        dtsMain,
+      },
+    };
+  }
+
+  return {
+    ts: null,
+  };
 }

--- a/src/formatPkg.js
+++ b/src/formatPkg.js
@@ -401,4 +401,6 @@ function getTypes(pkg) {
   if (pkg.typings) {
     return { ts: 'included' };
   }
+
+  return { ts: null };
 }

--- a/src/typescriptSupport.js
+++ b/src/typescriptSupport.js
@@ -8,7 +8,7 @@ import { fileExistsInUnpkg } from './unpkg.js';
  * @property {string} name
  * @property {string} version
  * @property {string} [main]
- * @property {string} [types]
+ * @property {{ ts: string | null }} [types]
  * @property {string} [typings]
  */
 
@@ -21,7 +21,7 @@ import { fileExistsInUnpkg } from './unpkg.js';
  */
 export async function getTypeScriptSupport(pkg) {
   // Already calculated in `formatPkg`
-  if (pkg.types) {
+  if (pkg.types.ts) {
     return { types: pkg.types };
   }
 

--- a/src/typescriptSupport.js
+++ b/src/typescriptSupport.js
@@ -4,11 +4,21 @@ import { validatePackageExists } from './npm.js';
 import { fileExistsInUnpkg } from './unpkg.js';
 
 /**
+ * @typedef Package
+ * @property {string} name
+ * @property {string} version
+ * @property {string} [main]
+ * @property {string} [types]
+ * @property {string} [typings]
+ */
+
+/**
  * Basically either
- *  - { types: { ts: null }}  for no existing TypeScript support
- *  - { types: { ts: "@types/module" }} - for definitely typed support
- *  - { types: { ts: "included" }} - for types shipped with the module
- * */
+ *   - { types: { ts: null }}  for no existing TypeScript support
+ *   - { types: { ts: "@types/module" }} - for definitely typed support
+ *   - { types: { ts: "included" }} - for types shipped with the module
+ * @param {Package} pkg
+ */
 export async function getTypeScriptSupport(pkg) {
   // Already calculated in `formatPkg`
   if (pkg.types) {
@@ -35,6 +45,9 @@ export async function getTypeScriptSupport(pkg) {
   return { types: { ts: null } };
 }
 
+/**
+ * @param {Array<Package>} pkgs
+ */
 export function getTSSupport(pkgs) {
   return Promise.all(pkgs.map(getTypeScriptSupport));
 }

--- a/src/typescriptSupport.js
+++ b/src/typescriptSupport.js
@@ -10,15 +10,9 @@ import { fileExistsInUnpkg } from './unpkg.js';
  *  - { types: { ts: "included" }} - for types shipped with the module
  * */
 export async function getTypeScriptSupport(pkg) {
-  // The cheap and simple (+ recommended by TS) way
-  // of adding a types section to your package.json
+  // Already calculated in `formatPkg`
   if (pkg.types) {
-    return { types: { ts: 'included' } };
-  }
-
-  // Older, but still works way of defining your types
-  if (pkg.typings) {
-    return { types: { ts: 'included' } };
+    return { types: pkg.types };
   }
 
   // The 2nd most likely is definitely typed


### PR DESCRIPTION
This fixes multiple things (I was too lazy to make multiple PRs)

1. calculate data based on the package which doesn't end up in the index in formatPkg
2. change the npm endpoint to `registry`

cc @orta 