### PR TITLE
fix(jsdelivr): fetch just npm hits

### DIFF
--- a/src/__tests__/__snapshots__/config.test.js.snap
+++ b/src/__tests__/__snapshots__/config.test.js.snap
@@ -176,7 +176,7 @@ Object {
       "type": "synonym",
     },
   ],
-  "jsDelivrHitsEndpoint": "https://data.jsdelivr.com/v1/stats/packages/month/all",
+  "jsDelivrHitsEndpoint": "https://data.jsdelivr.com/v1/stats/packages/npm/month/all",
   "maxObjSize": 450000,
   "npmDownloadsEndpoint": "https://api.npmjs.org/downloads",
   "npmRegistryEndpoint": "https://replicate.npmjs.com/registry",

--- a/src/config.js
+++ b/src/config.js
@@ -6,7 +6,8 @@ const defaultConfig = {
   npmRegistryEndpoint: 'https://replicate.npmjs.com/registry',
   npmDownloadsEndpoint: 'https://api.npmjs.org/downloads',
   npmRootEndpoint: 'https://registry.npmjs.org',
-  jsDelivrHitsEndpoint: 'https://data.jsdelivr.com/v1/stats/packages/month/all',
+  jsDelivrHitsEndpoint:
+    'https://data.jsdelivr.com/v1/stats/packages/npm/month/all',
   unpkgRoot: 'https://unpkg.com',
   maxObjSize: 450000,
   popularDownloadsRatio: 0.005,


### PR DESCRIPTION
Thanks to @martinkolarik in #371

This is 4.3MB vs 70MB, so will be nice for our memory usage. Speed is 200ms vs 3200ms