### PR TITLE
fix(lint): correct setup to require extension

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,6 @@ module.exports = {
   extends: ['algolia', 'algolia/jest'],
   rules: {
     'valid-jsdoc': 'off',
-    'import/extensions': ['error', 'ignorePackages'],
+    'import/extensions': ['error', 'always', { ignorePackages: true }],
   },
 };

--- a/src/__tests__/changelog.test.js
+++ b/src/__tests__/changelog.test.js
@@ -1,4 +1,4 @@
-import { getChangelogs, __RewireAPI__ } from '../changelog'; // eslint-disable-line import/named
+import { getChangelogs, __RewireAPI__ } from '../changelog.js'; // eslint-disable-line import/named
 
 const gotSnapshotUrls = new Set([
   'https://gitlab.com/janslow/gitlab-fetch/raw/master/CHANGELOG.md',

--- a/src/__tests__/config.test.js
+++ b/src/__tests__/config.test.js
@@ -1,4 +1,4 @@
-import config from '../config';
+import config from '../config.js';
 
 it('gets the correct keys from env variables', () => {
   // from mocked .env

--- a/src/__tests__/formatPkg.test.js
+++ b/src/__tests__/formatPkg.test.js
@@ -1,6 +1,6 @@
-import formatPkg from '../formatPkg';
+import formatPkg from '../formatPkg.js';
 import rawPackages from './rawPackages.json';
-import isISO8601 from 'validator/lib/isISO8601';
+import isISO8601 from 'validator/lib/isISO8601.js';
 
 it('transforms correctly', () => {
   rawPackages

--- a/src/__tests__/typescript.test.js
+++ b/src/__tests__/typescript.test.js
@@ -1,6 +1,6 @@
-import { getTypeScriptSupport } from '../typescriptSupport';
 jest.mock('../npm');
 jest.mock('../unpkg');
+import { getTypeScriptSupport } from '../typescriptSupport.js';
 import * as npm from '../npm/index.js';
 import { fileExistsInUnpkg } from '../unpkg.js';
 


### PR DESCRIPTION
Apparently the "ignorePackages" option also ignores some relative imports, where it shouldn't. The flag however works as expected.

This also would have caught the `../log` error we had earlier