### PR TITLE
feat(sentry): wait for the right amount of time.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,6 @@ import log from './log.js';
 import datadog from './datadog.js';
 import * as jsDelivr from './jsDelivr/index.js';
 import * as sentry from './utils/sentry.js';
-import wait from './utils/wait.js';
 
 log.info('🗿 npm ↔️ Algolia replication starts ⛷ 🐌 🛰');
 
@@ -328,9 +327,6 @@ async function watch(stateManager, mainIndex) {
 
 async function error(err) {
   sentry.report(err);
-
-  // Wait for sentry to report the error on their API
-  await wait(5000);
-
+  await sentry.drain();
   process.exit(1); // eslint-disable-line no-process-exit
 }

--- a/src/utils/sentry.js
+++ b/src/utils/sentry.js
@@ -9,7 +9,7 @@ Sentry.init({
   serverName: 'npm-search',
 });
 
-function report(err, extra = {}) {
+export function report(err, extra = {}) {
   log.error(err.message);
   if (!process.env.SENTRY_DSN) {
     log.error(err);
@@ -22,4 +22,10 @@ function report(err, extra = {}) {
   });
 }
 
-export { report };
+export function drain() {
+  const client = Sentry.getCurrentHub().getClient();
+  if (client) {
+    return client.close(2000);
+  }
+  return Promise.resolve();
+}

--- a/src/utils/wait.js
+++ b/src/utils/wait.js
@@ -1,7 +1,0 @@
-export default waitTime => {
-  if (waitTime <= 0) {
-    return Promise.resolve();
-  }
-
-  return new Promise(resolve => setTimeout(resolve, waitTime));
-};


### PR DESCRIPTION
I didn't test this, just found it in the docs: https://docs.sentry.io/error-reporting/configuration/draining/?platform=node