### PR TITLE
feat(index): try being resilient on "changes"

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -17,6 +17,8 @@ const defaultConfig = {
   indexName: 'npm-search',
   bootstrapIndexName: 'npm-search-bootstrap',
   replicateConcurrency: 10,
+  replicateRetry: 3,
+  watchRetry: 3,
   bootstrapConcurrency: 100,
   timeToRedoBootstrap: ms('2 weeks'),
   seq: null,


### PR DESCRIPTION
There doesn't seem to be a builtin way of retrying on .changes pouchdb (https://github.com/pouchdb/pouchdb/issues/7209)

I tried this out, but I have not been able to make this fail on my local machine, because I don't manage to set up a MITM where i can fake a wrong response.

Only  approve this if you have tried it out and see no issues 