### PR TITLE
handle bb redirect for private repo

### DIFF
--- a/src/__tests__/changelog.test.js
+++ b/src/__tests__/changelog.test.js
@@ -11,7 +11,7 @@ jest.mock('got', () => {
 
   return url =>
     gotSnapshotUrls.has(url)
-      ? Promise.resolve({ url })
+      ? Promise.resolve({ url, redirectUrls: [] })
       : Promise.reject(`got mock does not exist for ${url}`); // eslint-disable-line prefer-promise-reject-errors
 });
 

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -35,6 +35,8 @@ async function handledGot(file) {
     // bitbucket returns 200 for private repos
     // github returns a 404
     // I am unsure what gitlab does
+    result &&
+    result.redirectUrls &&
     result.redirectUrls.find(res =>
       res.startsWith('https://bitbucket.org/account/signin')
     )


### PR DESCRIPTION
Found this fun little catch in fetching info from BB. Feel free to DM me if you want a URL / package to test this on.

Second approach to this would be to somehow flag this in the `baseUrlMap` by complicating it to allow including a callback to perform additional checks, lmk what you think.