### PR TITLE
fix(size): more exact truncating of readme

### DIFF
--- a/src/__tests__/formatPkg.test.js
+++ b/src/__tests__/formatPkg.test.js
@@ -43,15 +43,15 @@ it('truncates long readmes', () => {
     readme: 'Hello, World! '.repeat(40000),
   };
   const formatted = formatPkg(object);
-  const truncatedEnding = '**TRUNCATED**';
+  const postfix = ' **TRUNCATED**';
   const ending = formatted.readme.substr(
-    formatted.readme.length - truncatedEnding.length
+    formatted.readme.length - postfix.length
   );
 
   const readmeLength = formatted.readme.length;
 
   expect(readmeLength).toBeLessThan(475000);
-  expect(ending).toBe(truncatedEnding);
+  expect(ending).toBe(postfix);
 
   expect(formatted).toMatchSnapshot({
     readme: expect.any(String),


### PR DESCRIPTION
before we were calculating the size to truncate wrong, and packages which were too long like (decentraland-renderer, which has no readme) can still error and halt the indexing process