### PR TITLE
fix(ts): migrate watch.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "doctoc": "doctoc --notitle --maxlevel 3 README.md",
     "lint": "eslint --ext=jsx,ts,tsx,js .",
     "prepare": "husky install",
-    "start": "UV_THREADPOOL_SIZE=12 node  -r dotenv/config  --async-stack-traces --max-old-space-size=920 dist/index.js",
+    "start": "UV_THREADPOOL_SIZE=12 node -r dotenv/config --async-stack-traces --max-old-space-size=920 dist/index.js",
     "test:watch": "jest --watchAll --no-watchman",
     "test": "jest --forceExit"
   },

--- a/src/@types/nice-package.ts
+++ b/src/@types/nice-package.ts
@@ -29,7 +29,7 @@ export interface NicePackageType {
   };
   owners?: GetUser[];
   readme?: string;
-  repository: string | PackageRepo;
+  repository?: string | Partial<PackageRepo> | Array<Partial<PackageRepo>>;
   scripts: Record<string, string>;
   schematics?: string;
   starsCount?: number;

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -4,14 +4,17 @@ import { config } from './config';
 import { datadog } from './utils/datadog';
 
 type State = {
-  seq: number | null;
+  seq: number | undefined;
   bootstrapDone: boolean;
   bootstrapLastId?: number;
+  stage: 'bootstrap' | 'watch';
 };
+
 const defaultState: State = {
   seq: config.seq,
   bootstrapDone: false,
   bootstrapLastId: undefined,
+  stage: 'bootstrap',
 };
 
 export class StateManager {
@@ -24,7 +27,7 @@ export class StateManager {
   }
 
   async check(): Promise<State> {
-    if (config.seq !== null) {
+    if (config.seq !== undefined) {
       return this.reset();
     }
 
@@ -46,6 +49,7 @@ export class StateManager {
     const { userData } = await this.algoliaIndex.getSettings();
     datadog.timing('stateManager.get', Date.now() - start);
 
+    this.currentState = userData;
     this.refreshed = true;
     return userData;
   }

--- a/src/__tests__/formatPkg.test.ts
+++ b/src/__tests__/formatPkg.test.ts
@@ -155,11 +155,11 @@ describe('adds vue-cli plugins', () => {
     name: '@dogs/vue-cli-plugin-dogs',
   };
 
-  const formattedDogs = formatPkg(pkg);
-  const formattedUnofficialDogs = formatPkg(unofficialDogs);
-  const formattedScopedDogs = formatPkg(scopedDogs);
-
   it('should format correctly', () => {
+    const formattedDogs = formatPkg(pkg);
+    const formattedUnofficialDogs = formatPkg(unofficialDogs);
+    const formattedScopedDogs = formatPkg(scopedDogs);
+
     expect(formattedDogs.keywords).toEqual([]);
     expect(formattedUnofficialDogs.keywords).toEqual([]);
     expect(formattedScopedDogs.keywords).toEqual([]);

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,10 +16,10 @@ export const config = {
   apiKey: '',
   indexName: 'npm-search',
   bootstrapIndexName: 'npm-search-bootstrap',
-  replicateConcurrency: 10,
+  replicateConcurrency: 1,
   bootstrapConcurrency: 25,
   timeToRedoBootstrap: ms('2 weeks'),
-  seq: null,
+  seq: undefined,
   indexSettings: {
     searchableAttributes: [
       'unordered(_searchInternal.popularName)',

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import * as jsDelivr from './jsDelivr/index';
 import { datadog } from './utils/datadog';
 import { log } from './utils/log';
 import * as sentry from './utils/sentry';
-import * as watch from './watch.js';
+import * as watch from './watch';
 
 log.info('🗿 npm ↔️ Algolia replication starts ⛷ 🐌 🛰');
 

--- a/src/npm/types.ts
+++ b/src/npm/types.ts
@@ -10,15 +10,6 @@ export interface GetInfo {
   update_seq: number;
 }
 
-export interface Options {
-  include_docs: boolean;
-  conflicts: boolean;
-  attachments: boolean;
-  limit?: number;
-  startkey?: string;
-  skip?: number;
-}
-
 export interface GetUser {
   name: string;
   email?: string;

--- a/src/utils/sentry.ts
+++ b/src/utils/sentry.ts
@@ -1,4 +1,4 @@
-import Sentry from '@sentry/node';
+import * as Sentry from '@sentry/node';
 
 import { log } from './log';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
     /* Basic Options */
     // "incremental": true,                         /* Enable incremental compilation */
-    "target": "es5", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', 'ES2021', or 'ESNEXT'. */
+    "target": "es2017", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', 'ES2021', or 'ESNEXT'. */
     "module": "commonjs", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     "lib": [
       "es2017"
@@ -42,7 +42,7 @@
     // "noImplicitOverride": true,                  /* Ensure overriding members in derived classes are marked with an 'override' modifier. */
     // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
     /* Module Resolution Options */
-    // "moduleResolution": "node",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "node", /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
     // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
@@ -67,5 +67,8 @@
   },
   "include": [
     "src/*"
+  ],
+  "exclude": [
+    "node_modules"
   ]
 }


### PR DESCRIPTION
The most complexe one. 
I had to change the logic to fix the types (a good thing but introduces more changes than what I wanted).

main issues:
- Catchup was processing multiple updates in parallel but it could have an update and a delete for the same package, 
which could explain one of the issue we have with deleted packages still in the index.
- Repo provided by NicePackage was not as "clean" as we wanted, realised that while testing with real update.
- We were filtering out `deleted` packages, in `changesConsumer` (Line 127, 131) effectively never deleting packages.
