### PR TITLE
fix(package.json): add repo url

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,5 +100,10 @@
       "node_modules",
       "lib"
     ]
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/algolia/npm-search.git"
+  },
+  "homepage": "https://github.com/algolia/npm-search"
 }


### PR DESCRIPTION
Seems like we need a repo url to allow semantic release 
https://github.com/semantic-release/semantic-release/issues/1095