### PR TITLE
feat: process package in queue instead of batch

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,7 @@
     "algolia/typescript"
   ],
   "rules": {
+    "no-continue": "off",
     "valid-jsdoc": "off",
     "import/extensions": [
       "error",

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,8 @@ RUN true \
 # This image must have the minimum amount of layers
 FROM node:14.16.1-alpine as final
 
+ENV NODE_ENV production
+
 # Do not use root to run the app
 USER node
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "async": "3.2.0",
     "bunyan": "1.8.15",
     "bunyan-debug-stream": "2.0.0",
+    "chalk": "4.1.1",
     "dtrace-provider": "0.8.8",
     "escape-html": "1.0.3",
     "got": "11.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-search",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "author": {
     "name": "Algolia, Inc.",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,6 +7,7 @@ echo "Releasing: $current"
 echo ""
 
 docker build \
+  --platform linux/amd64 \
   -t algolia/npm-search \
   -t "algolia/npm-search:${current}" \
   .

--- a/src/__tests__/saveDocs.test.ts
+++ b/src/__tests__/saveDocs.test.ts
@@ -213,7 +213,7 @@ it('should be similar batch vs one', async () => {
 
   const row = { id: '', key: 'preact', value: { rev: 'a' }, doc: preact };
   await saveDocs({ docs: [row], index });
-  await saveDoc({ row, index });
+  await saveDoc({ row: preact, index });
 
   expect(index.saveObjects).toHaveBeenCalledWith([clean]);
   expect(index.saveObject).toHaveBeenCalledWith(clean);

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -170,5 +170,5 @@ function createPkgConsumer(
     } finally {
       datadog.timing('loop', Date.now() - start);
     }
-  }, 3);
+  }, config.bootstrapConcurrency);
 }

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -85,7 +85,7 @@ export async function run(
   while (processing) {
     logProgress(done);
 
-    await wait(5000);
+    await wait(config.prefetchWaitBetweenPage);
 
     processing = !prefetcher.isFinished;
     done = 0;

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -105,7 +105,6 @@ export async function getChangelog(
     for (const file of filelist) {
       const name = path.basename(file.name);
       if (!fileRegex.test(name)) {
-        // eslint-disable-next-line no-continue
         continue;
       }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -172,6 +172,8 @@ export const config = {
   expiresAt: ms('30 days'),
   popularExpiresAt: ms('7 days'),
   cacheTotalDownloads: ms('1 minute'),
+  prefetchWaitBetweenPage: 5000,
+  prefetchMaxIdle: 100,
 };
 
 export type Config = typeof config;

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,6 @@ async function main(): Promise<void> {
 
   // then we figure out which updates we missed since
   // the last time main index was updated
-  log.info('🚀  Launching Watch');
   await watch.run(stateManager, mainIndex);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,10 @@ async function main(): Promise<void> {
   createAPI();
 
   // first we make sure the bootstrap index has the correct settings
-  log.info('💪  Setting up Algolia');
+  log.info('💪  Setting up Algolia', [
+    config.bootstrapIndexName,
+    config.indexName,
+  ]);
   const {
     client: algoliaClient,
     mainIndex,

--- a/src/jsDelivr/index.ts
+++ b/src/jsDelivr/index.ts
@@ -95,7 +95,7 @@ export async function getFilesList(
     });
     files = response.body.files;
   } catch (e) {
-    log.error(`Failed to fetch ${url}`, e);
+    log.error(`Failed to fetch ${url}`, e.message);
   }
 
   datadog.timing('jsdelivr.getFilesList', Date.now() - start);

--- a/src/npm/Prefetcher.ts
+++ b/src/npm/Prefetcher.ts
@@ -34,15 +34,11 @@ export class Prefetcher {
   }
 
   async getNext(): Promise<PrefetchedPkg> {
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
-      if (this.#ready.length <= 0) {
-        await wait(100);
-        continue;
-      }
-
-      return this.#ready.shift()!;
+    while (this.#ready.length <= 0) {
+      await wait(100);
     }
+
+    return this.#ready.shift()!;
   }
 
   async launch(): Promise<void> {

--- a/src/npm/Prefetcher.ts
+++ b/src/npm/Prefetcher.ts
@@ -1,0 +1,76 @@
+import type { DocumentListParams } from 'nano';
+
+import { config } from '../config';
+import { log } from '../utils/log';
+import { wait } from '../utils/wait';
+
+import type { GetPackage } from './types';
+
+import * as npm from './index';
+
+export class Prefetcher {
+  #limit: number = config.bootstrapConcurrency;
+  #ready: GetPackage[] = [];
+  #nextKey: string | null = null;
+  #running: boolean = false;
+  #offset: number = 0;
+  #finished: boolean = false;
+
+  constructor(opts: { nextKey: string | null }) {
+    this.#nextKey = opts.nextKey;
+  }
+
+  get offset(): number {
+    return this.#offset;
+  }
+
+  get isFinished(): boolean {
+    return this.#finished;
+  }
+
+  async getNext(): Promise<GetPackage> {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      if (this.#ready.length <= 0) {
+        await wait(100);
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+
+      return this.#ready.shift()!;
+    }
+  }
+
+  async launch(): Promise<void> {
+    this.#running = true;
+    while (this.#running) {
+      await this.fetchOnePage();
+
+      await wait(5000);
+    }
+  }
+
+  private async fetchOnePage(): Promise<void> {
+    const options: Partial<DocumentListParams> = {
+      limit: this.#limit,
+      include_docs: false,
+    };
+
+    if (this.#nextKey) {
+      options.startkey = this.#nextKey;
+      options.skip = 1;
+    }
+    const { rows: packages, offset } = await npm.findAll(options);
+    this.#offset = offset;
+
+    if (packages.length <= 0) {
+      this.#finished = true;
+      this.#running = false;
+      return;
+    }
+
+    log.info('  - [pf] received', packages.length, 'packages');
+
+    this.#nextKey = packages[packages.length - 1].id;
+  }
+}

--- a/src/npm/Prefetcher.ts
+++ b/src/npm/Prefetcher.ts
@@ -15,7 +15,7 @@ export class Prefetcher {
   #running: boolean = false;
   #offset: number = 0;
   #finished: boolean = false;
-  #maxIdle = 100;
+  #maxIdle = config.prefetchMaxIdle;
 
   constructor(opts: { nextKey: string | null }) {
     this.#nextKey = opts.nextKey;
@@ -45,7 +45,7 @@ export class Prefetcher {
     this.#running = true;
     while (this.#running) {
       if (this.#ready.length >= this.#maxIdle) {
-        await wait(5000);
+        await wait(config.prefetchWaitBetweenPage);
         continue;
       }
 

--- a/src/npm/Prefetcher.ts
+++ b/src/npm/Prefetcher.ts
@@ -4,36 +4,40 @@ import { config } from '../config';
 import { log } from '../utils/log';
 import { wait } from '../utils/wait';
 
-import type { GetPackage } from './types';
-
 import * as npm from './index';
+
+export type PrefetchedPkg = { id: string };
 
 export class Prefetcher {
   #limit: number = config.bootstrapConcurrency;
-  #ready: GetPackage[] = [];
+  #ready: PrefetchedPkg[] = [];
   #nextKey: string | null = null;
   #running: boolean = false;
   #offset: number = 0;
   #finished: boolean = false;
+  #maxIdle = 100;
 
   constructor(opts: { nextKey: string | null }) {
     this.#nextKey = opts.nextKey;
   }
 
   get offset(): number {
-    return this.#offset;
+    return this.#offset + this.#limit - this.#ready.length;
+  }
+
+  get idleCount(): number {
+    return this.#ready.length;
   }
 
   get isFinished(): boolean {
     return this.#finished;
   }
 
-  async getNext(): Promise<GetPackage> {
+  async getNext(): Promise<PrefetchedPkg> {
     // eslint-disable-next-line no-constant-condition
     while (true) {
       if (this.#ready.length <= 0) {
         await wait(100);
-        // eslint-disable-next-line no-continue
         continue;
       }
 
@@ -44,9 +48,12 @@ export class Prefetcher {
   async launch(): Promise<void> {
     this.#running = true;
     while (this.#running) {
-      await this.fetchOnePage();
+      if (this.#ready.length >= this.#maxIdle) {
+        await wait(5000);
+        continue;
+      }
 
-      await wait(5000);
+      await this.fetchOnePage();
     }
   }
 
@@ -61,16 +68,17 @@ export class Prefetcher {
       options.skip = 1;
     }
     const { rows: packages, offset } = await npm.findAll(options);
-    this.#offset = offset;
 
     if (packages.length <= 0) {
       this.#finished = true;
       this.#running = false;
+      this.#offset = offset;
+      log.info('[pf] done');
       return;
     }
 
-    log.info('  - [pf] received', packages.length, 'packages');
-
+    this.#ready.push(...packages);
+    this.#offset = offset;
     this.#nextKey = packages[packages.length - 1].id;
   }
 }

--- a/src/npm/types.ts
+++ b/src/npm/types.ts
@@ -1,3 +1,5 @@
+import type { DocumentLookupFailure } from 'nano';
+
 export interface PackageDownload {
   downloads: number;
   package: string;
@@ -64,4 +66,15 @@ export interface GetPackage {
   contributors?: Array<{ name: string }>;
   repository?: PackageRepo;
   schematics?: string;
+}
+
+export interface GetPackageLight {
+  name: string;
+  'dist-tags': Record<string, string>;
+  versions: Record<string, Pick<GetVersion, 'name' | 'version' | 'dist'>>;
+  modified: string;
+}
+
+export function isFailure(change: any): change is DocumentLookupFailure {
+  return change.error && !change.id;
 }

--- a/src/saveDocs.ts
+++ b/src/saveDocs.ts
@@ -42,6 +42,7 @@ export async function saveDocs({
     return Promise.resolve(0);
   }
   log.info('  => ', names);
+
   log.info('  Adding metadata...');
 
   let start2 = Date.now();
@@ -64,12 +65,12 @@ export async function saveDoc({
   row,
   index,
 }: {
-  row: DocumentResponseRow<GetPackage>;
+  row: GetPackage;
   index: SearchIndex;
 }): Promise<void> {
   const start = Date.now();
 
-  const formatted = formatPkg(row.doc!);
+  const formatted = formatPkg(row);
 
   datadog.timing('formatPkg', Date.now() - start);
 

--- a/src/saveDocs.ts
+++ b/src/saveDocs.ts
@@ -78,20 +78,13 @@ export async function saveDoc({
     return;
   }
 
-  log.info('  => ', formatted.name);
-  log.info('  Adding metadata...');
-
   let start2 = Date.now();
   const pkg = await addMetaData(formatted);
   datadog.timing('saveDocs.addMetaData.one', Date.now() - start2);
 
-  log.info(` Saving...`);
-
   start2 = Date.now();
   await index.saveObject(pkg);
   datadog.timing('saveDocs.saveObject.one', Date.now() - start2);
-
-  log.info(`  Saved`);
 
   datadog.timing('saveDocs.one', Date.now() - start);
 }

--- a/src/typescript/index.ts
+++ b/src/typescript/index.ts
@@ -79,7 +79,6 @@ export function getTypeScriptSupport(
 
     for (const file of filelist) {
       if (!file.name.endsWith('.d.ts')) {
-        // eslint-disable-next-line no-continue
         continue;
       }
 

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -5,7 +5,8 @@ const stream = bunyanDebugStream({
   showDate: process.env.NODE_ENV !== 'production',
   showProcess: false,
   showLoggerName: false,
-  showPid: process.env.NODE_ENV !== 'production',
+  showPid: false,
+  showLevel: process.env.NODE_ENV === 'production',
 });
 
 export const log = bunyan.createLogger({

--- a/src/utils/wait.ts
+++ b/src/utils/wait.ts
@@ -1,0 +1,6 @@
+// Coming in nodejs 16
+export function wait(waitTime: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, waitTime);
+  });
+}

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -1,12 +1,13 @@
 import type { SearchIndex } from 'algoliasearch';
 import type { QueueObject } from 'async';
 import { queue } from 'async';
+import chalk from 'chalk';
 import type { DatabaseChangesResultItem } from 'nano';
 
 import type { StateManager } from './StateManager';
 import * as npm from './npm';
 import { isFailure } from './npm/types';
-import { saveDocs } from './saveDocs';
+import { saveDoc } from './saveDocs';
 import { datadog } from './utils/datadog';
 import { log } from './utils/log';
 import * as sentry from './utils/sentry';
@@ -41,6 +42,10 @@ export async function run(
   stateManager: StateManager,
   mainIndex: SearchIndex
 ): Promise<void> {
+  log.info('-----');
+  log.info('🚀  Watch: starting');
+  log.info('-----');
+
   await stateManager.save({
     stage: 'watch',
   });
@@ -49,7 +54,9 @@ export async function run(
 
   await watch(stateManager);
 
-  log.info('🚀  watch is done');
+  log.info('-----');
+  log.info('🚀  Watch: done');
+  log.info('-----');
 }
 
 /**
@@ -94,7 +101,6 @@ async function loop(
   mainIndex: SearchIndex,
   change: DatabaseChangesResultItem
 ): Promise<void> {
-  const start = Date.now();
   datadog.increment('packages');
 
   if (!change.id) {
@@ -107,20 +113,18 @@ async function loop(
     // Delete package directly in index
     // Filter does not support async/await but there is no concurrency issue with this
     mainIndex.deleteObject(change.id);
-    log.info(`🚀  Deleted ${change.id}`);
+    log.info(`Deleted`, change.id);
     return;
   }
 
-  const res = (await npm.getDocs({ keys: [change.id] })).rows[0];
+  const res = await npm.getDoc(change.id);
 
   if (isFailure(res)) {
     log.error('Got an error', res.error);
     return;
   }
 
-  await saveDocs({ docs: [res], index: mainIndex });
-
-  datadog.timing('watch.loop', Date.now() - start);
+  await saveDoc({ row: res, index: mainIndex });
 }
 
 /**
@@ -129,10 +133,12 @@ async function loop(
  */
 function logProgress(seq: number): void {
   log.info(
-    `🚀  Synced %d/%d changes (%d%)`,
+    chalk.dim.italic
+      .white`[progress] Synced %d/%d changes (%d%) (%s remaining)`,
     seq,
     totalSequence,
-    Math.floor((Math.max(seq, 1) / totalSequence) * 100)
+    Math.floor((Math.max(seq, 1) / totalSequence) * 100),
+    totalSequence - seq
   );
 }
 
@@ -152,16 +158,22 @@ function createChangeConsumer(
   mainIndex: SearchIndex
 ): QueueObject<DatabaseChangesResultItem> {
   return queue<DatabaseChangesResultItem>(async (change) => {
+    const start = Date.now();
+
     const seq = change.seq;
-    log.info(`🚀  Received change [%s]`, seq);
+    log.info(`Start:`, change.id);
+
     try {
       await loop(mainIndex, change);
       await stateManager.save({
         seq,
       });
-      logProgress(seq);
     } catch (err) {
       sentry.report(err);
+    } finally {
+      log.info(`Done:`, change.id);
+      logProgress(seq);
+      datadog.timing('watch.loop', Date.now() - start);
     }
   }, 1);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2244,6 +2244,14 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
+chalk@4.1.1, chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
+  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
@@ -2260,14 +2268,6 @@ chalk@^2.3.2:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
-  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
 
 char-regex@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Most batch were slowed down by the slowest package, which means fast packages were still not indexed.
Here, we take advantage of NodeJs being good with async/sync and indexing sooner.

The prefetcher, only prefetch the names of the packages, so it's not filling the memory but still provide a way to fill the queue rapidly.

In the queue we fetch package per package, which is a bit slower than fetching a pages of doc, but results in less memory used and gc sooner too.
The processing itself is the same as before, except we don't do batch but one by one (see #652) 

--- 

Except that, I have been extensively testing in Google Compute Engine, to replace slow and expensive Heroku.
I lack a deploy script, monitoring and everything else, but it's working very fine (see comments below). 
GCE being very "manual" (except the start of the docker image and the CPU tracking there is nothing 🤦🏻 ), I think I'll go for the overkill solution -> Kubernetes, but at least it has native monitoring, auto-restart and we know the stack perfectly at Algolia.