### PR TITLE
fix: stop using unpkg for changelog

### DIFF
--- a/src/__tests__/changelog.test.ts
+++ b/src/__tests__/changelog.test.ts
@@ -6,7 +6,6 @@ jest.mock('got', () => {
     'https://raw.githubusercontent.com/algolia/algoliasearch-netlify/master/CHANGELOG.md',
     'https://bitbucket.org/atlassian/aui/raw/master/changelog.md',
     'https://raw.githubusercontent.com/expressjs/body-parser/master/HISTORY.md',
-    'https://unpkg.com/@atlaskit/button@13.3.7/CHANGELOG.md',
   ]);
 
   return (url: string): Promise<{ url: string; redirectUrls: string[] }> => {
@@ -131,20 +130,6 @@ it('should get changelog for github', async () => {
   const [{ changelogFilename }] = await getChangelogs([pkg], []);
   expect(changelogFilename).toBe(
     'https://raw.githubusercontent.com/algolia/algoliasearch-netlify/master/CHANGELOG.md'
-  );
-});
-
-it('should get changelog from unpkg if there is no repository field', async () => {
-  const pkg = {
-    name: '@atlaskit/button',
-    version: '13.3.7',
-    repository: null,
-  };
-
-  const [{ changelogFilename }] = await getChangelogs([pkg], []);
-
-  expect(changelogFilename).toBe(
-    'https://unpkg.com/@atlaskit/button@13.3.7/CHANGELOG.md'
   );
 });
 

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -3,7 +3,6 @@ import path from 'path';
 import race from 'promise-rat-race';
 
 import type { RawPkg, Repo } from './@types/pkg';
-import { config } from './config';
 import * as jsDelivr from './jsDelivr/index';
 import { datadog } from './utils/datadog';
 import { request } from './utils/request';
@@ -115,36 +114,27 @@ export async function getChangelog(
 
     datadog.increment('jsdelivr.getChangelog.miss');
 
-    const { repository, name, version } = pkg;
+    const { repository } = pkg;
 
-    // Rollback to brute-force the source code
-    const unpkgFiles = fileOptions.map(
-      (file) => `${config.unpkgRoot}/${name}@${version}/${file}`
-    );
-
-    if (repository === null) {
-      return await raceFromPaths(unpkgFiles);
+    if (repository === null || !repository.host) {
+      return { changelogFilename: null };
     }
 
-    const user = repository.user || '';
-    const project = repository.project || '';
     const host = repository.host || '';
-    if (user.length < 1 || project.length < 1) {
-      return await raceFromPaths(unpkgFiles);
+    const knownHost = baseUrlMap.get(host);
+
+    // No known git hosts
+    if (!knownHost) {
+      return { changelogFilename: null };
     }
 
-    // Check if we know how to handle this host
-    if (!baseUrlMap.has(host)) {
-      return await raceFromPaths(unpkgFiles);
-    }
-
-    const baseUrl = baseUrlMap.get(host)!(repository);
-
+    const baseUrl = knownHost(repository);
     const files = fileOptions.map((file) =>
       [baseUrl.replace(/\/$/, ''), file].join('/')
     );
 
-    return await raceFromPaths([...files, ...unpkgFiles]);
+    // Brute-force from git host
+    return await raceFromPaths([...files]);
   } finally {
     datadog.timing('changelogs.getChangelog', Date.now() - start);
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -156,7 +156,6 @@ export const config = {
   jsDelivrPackageEndpoint: 'https://data.jsdelivr.com/v1/package/npm',
   typescriptTypesIndex:
     'https://typespublisher.blob.core.windows.net/typespublisher/data/search-index-min.json',
-  unpkgRoot: 'https://unpkg.com',
   maxObjSize: 450000,
   popularDownloadsRatio: 0.005,
   appId: 'OFCNCOG2CU',


### PR DESCRIPTION
Now that we pass jsdelivr file list there is no point in loading the same data less efficiently from unpkg.
