### PR TITLE
fix: mini fixes

### DIFF
--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -92,7 +92,6 @@ export async function run(
 
     // Push nothing to trigger event
     consumer.push(null as any);
-    processing = false;
   }
 
   consumer.pause();
@@ -159,7 +158,7 @@ function createPkgConsumer(
     try {
       datadog.increment('packages');
 
-      const res = await npm.getDoc(pkg.id);
+      const res = await npm.getDoc(pkg.id, pkg.value.rev);
 
       if (isFailure(res)) {
         log.error('Got an error', res.error);

--- a/src/npm/Prefetcher.ts
+++ b/src/npm/Prefetcher.ts
@@ -1,12 +1,17 @@
-import type { DocumentListParams } from 'nano';
+import type { DocumentListParams, DocumentResponseRow } from 'nano';
 
 import { config } from '../config';
 import { log } from '../utils/log';
 import { wait } from '../utils/wait';
 
+import type { GetPackage } from './types';
+
 import * as npm from './index';
 
-export type PrefetchedPkg = { id: string };
+export type PrefetchedPkg = Pick<
+  DocumentResponseRow<GetPackage>,
+  'id' | 'value'
+>;
 
 export class Prefetcher {
   #limit: number = config.bootstrapConcurrency;

--- a/src/npm/index.ts
+++ b/src/npm/index.ts
@@ -84,10 +84,13 @@ async function getChanges(
   return results;
 }
 
-async function getDoc(name: string): Promise<DocumentGetResponse & GetPackage> {
+async function getDoc(
+  name: string,
+  rev: string
+): Promise<DocumentGetResponse & GetPackage> {
   const start = Date.now();
 
-  const doc = await db.get(name);
+  const doc = await db.get(name, { rev });
 
   datadog.timing('npm.getDoc', Date.now() - start);
 


### PR DESCRIPTION
- Slipped a processing = false
- Use `rev` to fetch package at the version we received the change for, not the future version
- Handle deleted error