### PR TITLE
fix: various

### DIFF
--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -96,7 +96,7 @@ export async function run(
 
   consumer.pause();
 
-  // The while will stop before the queue has been fully consumed
+  // While we no longer are in "processing" mode, it's possible that there's a last iteration in the queue
   await consumer.drain();
 
   await stateManager.save({

--- a/src/config.ts
+++ b/src/config.ts
@@ -164,7 +164,7 @@ export const config = {
   indexName: 'npm-search',
   bootstrapIndexName: 'npm-search-bootstrap',
   bootstrapConcurrency: 25,
-  timeToRedoBootstrap: ms('2 weeks'),
+  timeToRedoBootstrap: ms('1 month'),
   seq: undefined,
   indexSettings,
   indexSynonyms,

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -140,12 +140,14 @@ async function loop(
  *
  */
 function logProgress(seq: number): void {
+  datadog.gauge('watch.sequence.total', totalSequence);
+  datadog.gauge('watch.sequence.current', seq);
   log.info(
     chalk.dim.italic
-      .white`[progress] Synced %d/%d changes (%d%) (%s remaining)`,
+      .white`[progress] Synced %d/%d changes (%s%) (%s remaining)`,
     seq,
     totalSequence,
-    Math.floor((Math.max(seq, 1) / totalSequence) * 100),
+    ((Math.max(seq, 1) / totalSequence) * 100).toFixed(2),
     totalSequence - seq
   );
 }


### PR DESCRIPTION
- Increase bootstrap period because it should be less needed now and it takes too much time to reprocess that often
- Log progress to datadog to remove the need to read logs to see progress
- Log percent in 00.00% format for more precision
- Drain queue before moving index and await the copy (we missed the last few packages in the bootstrap)