### PR TITLE
fix: naive retry strategy

### DIFF
--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -57,6 +57,7 @@ export class Bootstrap {
       await algolia.putDefaultSettings(this.mainIndex, config);
       log.info('⛷   Bootstrap: done');
       log.info('-----');
+
       return;
     }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -175,6 +175,7 @@ export const config = {
   prefetchMaxIdle: 100,
   retryMax: 2,
   retrySkipped: ms('1 minute'),
+  retryBackoffPow: 3,
 };
 
 export type Config = typeof config;

--- a/src/config.ts
+++ b/src/config.ts
@@ -173,6 +173,8 @@ export const config = {
   cacheTotalDownloads: ms('1 minute'),
   prefetchWaitBetweenPage: 5000,
   prefetchMaxIdle: 100,
+  retryMax: 2,
+  retrySkipped: ms('1 minute'),
 };
 
 export type Config = typeof config;

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -98,7 +98,7 @@ export class Watch {
         since: String(seq),
       })
       .on('change', (change) => {
-        changesConsumer.push(change);
+        changesConsumer.push({ change, retry: 0 });
 
         // on:change will not wait for us to process to trigger again
         // So we need to control the fetch manually otherwise it will fetch thousand/millions of update in advance

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -58,7 +58,7 @@ export class Watch {
    *  It will retry the same package after an exponential backoff, N times.
    *
    *  After N times, this update will be discarded in the this.skipped
-   *  This Map will be regularly reprocessed to avoid loosing jobs.
+   *  This Map will be regularly reprocessed to avoid losing jobs.
    *  This is an in-memory only retry, if the process is stopped, skipped job are lost.
    */
   async run(): Promise<void> {

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -174,7 +174,7 @@ export class Watch {
     }
 
     if (change.deleted) {
-      // Delete package directly in index
+      // changesConsumer deletes the package directly in the index
       throw new Error('deleted');
     }
     const res = await npm.getDoc(change.id, change.changes[0].rev);


### PR DESCRIPTION
This should help #778 

Two retry strategy:
- Exponential backoff that blocks the queue
  Useful if a service is down, skipped the job right away would just make every other fail faster.
  
- "Mid-term" retry.
  After 3 retries, the jobs are put aside and tried later until they pass or a new update for this package comes in