### PR TITLE
fix(style): resilient when not a string

### DIFF
--- a/src/formatPkg.ts
+++ b/src/formatPkg.ts
@@ -640,7 +640,7 @@ function getModuleTypes(pkg: NicePackageType): ModuleType[] {
 
 function getStyleTypes(pkg: NicePackageType): StyleType[] {
   // style not declared - we will detect it later based on file list
-  if (!pkg.style) {
+  if (typeof pkg.style !== 'string') {
     return [];
   }
 


### PR DESCRIPTION
Not sure in which case this happens, but we had an error `pkg.style.split` is not a function