### PR TITLE
feat(ranking): only boost actually exact matches

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,8 @@ const indexSettings: Settings = {
     'owners.name',
   ],
   attributesForFaceting: [
-    'filterOnly(_searchInternal.alternativeNames)' /* optionalFacetFilters to boost the name */,
+    'name' /* optional filter for exact matching */,
+    'filterOnly(_searchInternal.alternativeNames)',
     'filterOnly(bin)',
     'searchable(keywords)',
     'searchable(computedKeywords)',
@@ -85,14 +86,14 @@ const indexRules: Rule[] = [
     objectID: 'promote-exact',
     description: 'promote exact matches',
     condition: {
-      pattern: '{facet:_searchInternal.alternativeNames}',
+      pattern: '{facet:name}',
       anchoring: 'is',
     },
     consequence: {
       params: {
         automaticOptionalFacetFilters: [
           {
-            facet: '_searchInternal.alternativeNames',
+            facet: 'name',
           },
         ],
       },


### PR DESCRIPTION
Some examples where the previous filter worked better:

places -> places.js is a better first match than places, but the other results are fairly relevant (except the babel one)

Places only exact match works better
- react (removes re-act and reactjs which are bad packages)
- bootstrap (removes unpopular bootstrapjs package)

You can check these changes out in the npm-search_old index where I've tried out the change

cc @MartinKolarik 