### PR TITLE
fix(config): increase requests timeout

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -184,6 +184,9 @@ export const config = {
   alternativeNamesNpmDownloadsThreshold: 5000,
   alternativeNamesJsDelivrHitsThreshold: 10000,
 
+  // http
+  defaultRequestTimeout: ms('30 seconds'),
+
   // Watch
   watchMaxPrefetch: 10,
   watchMinUnpause: 5,

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -4,6 +4,8 @@ import https from 'https';
 import type { OptionsOfJSONResponseBody } from 'got';
 import got from 'got';
 
+import { config } from '../config';
+
 // eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-commonjs
 const { version } = require('../../package.json');
 
@@ -26,12 +28,12 @@ export async function request<TRes>(
   opts: OptionsOfJSONResponseBody
 ) {
   return await got<TRes>(url, {
+    timeout: config.defaultRequestTimeout,
     ...opts,
     headers: {
       ...(opts.headers || {}),
       'user-agent': USER_AGENT,
     },
-    timeout: 15000,
     dnsCache: true,
     dnsLookupIpVersion: 'ipv4',
     agent: {

--- a/src/utils/sentry.ts
+++ b/src/utils/sentry.ts
@@ -9,6 +9,7 @@ Sentry.init({
   release: version,
   environment: 'prod',
   serverName: 'npm-search',
+  maxBreadcrumbs: 20,
   ignoreErrors: [
     /error happened in your connection/,
     /503 Service Unavailable/,


### PR DESCRIPTION
- A lot of requests are failing because of timeouts
- Bonus: reduce number of breadcrumbs in Sentry because it's useless in a long running process