### PR TITLE
fix(config): use popularAlternativeNames

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -5,12 +5,12 @@ const indexSettings: Settings = {
   searchableAttributes: [
     'unordered(_searchInternal.popularName)',
     'name, description, keywords',
-    '_searchInternal.alternativeNames',
+    '_searchInternal.popularAlternativeNames',
     'owner.name',
     'owners.name',
   ],
   attributesForFaceting: [
-    'filterOnly(_searchInternal.alternativeNames)' /* optionalFacetFilters to boost the name */,
+    'filterOnly(_searchInternal.popularAlternativeNames)' /* optionalFacetFilters to boost the name */,
     'filterOnly(bin)',
     'searchable(keywords)',
     'searchable(computedKeywords)',
@@ -87,14 +87,14 @@ const indexRules: Rule[] = [
     objectID: 'promote-exact',
     description: 'promote exact matches',
     condition: {
-      pattern: '{facet:_searchInternal.alternativeNames}',
+      pattern: '{facet:_searchInternal.popularAlternativeNames}',
       anchoring: 'is',
     },
     consequence: {
       params: {
         automaticOptionalFacetFilters: [
           {
-            facet: '_searchInternal.alternativeNames',
+            facet: '_searchInternal.popularAlternativeNames',
           },
         ],
       },


### PR DESCRIPTION
As per https://github.com/algolia/npm-search/issues/941#issuecomment-1161735260, this should NOT be applied to the main index yet, only the one that's being rebuilt.