### PR TITLE
chore: add renovate weekly PR

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,20 @@
+name: Renovate
+on:
+  schedule:
+    - cron: '0 14 * * 4'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      - name: Renovate Automatic Branch
+        uses: bodinsamuel/renovate-automatic-branch@v1
+        with:
+          github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+          repo-owner: algolia
+          repo-name: npm-search

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Renovate Automatic Branch
         uses: bodinsamuel/renovate-automatic-branch@v1
         with:
-          github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           repo-owner: algolia
           repo-name: npm-search

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,0 +1,8 @@
+{
+  "extends": [
+    "algolia"
+  ],
+  "baseBranches": [
+    "chore/renovateBaseBranch"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -20,12 +20,6 @@
     "docker:build": "./scripts/build.sh",
     "docker:release": "VERSION=$(node -e \"console.log(require('./package.json').version)\") && echo \"Releasing $VERSION\" && docker push algolia/npm-search && docker push algolia/npm-search:$VERSION"
   },
-  "renovate": {
-    "extends": [
-      "config:js-app",
-      "algolia"
-    ]
-  },
   "license": "MIT",
   "dependencies": {
     "@algolia/requester-node-http": "4.14.2",


### PR DESCRIPTION
Since we can't maintain our deps correctly, let's try with the strategy we adopted on some others repo across the org.
It creates a branch and a PR every friday, renovate will use it.
That way it can auto merge all the deps that has a valid CI, and we have only one PR to approve