### PR TITLE
fix(config): update jsDelivrHitsEndpoint url

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -156,7 +156,7 @@ export const config = {
   npmDownloadsEndpoint: 'https://api.npmjs.org/downloads',
   npmRootEndpoint: 'https://registry.npmjs.org',
   jsDelivrHitsEndpoint:
-    'https://data.jsdelivr.com/v1/stats/packages/npm/month/all',
+    'https://data-jsdelivr-com-preview.onrender.com/v1/stats/packages/all?period=month&type=npm',
   jsDelivrPackageEndpoint: 'https://data.jsdelivr.com/v1/package/npm',
   typescriptTypesIndex:
     'https://typespublisher.blob.core.windows.net/typespublisher/data/search-index-min.json',


### PR DESCRIPTION
The current URL uses an undocumented feature we'll have to remove soon due to path conflicts with some new endpoints. To avoid any disruption here, this PR switches to a new URL on our preview environment.

Once we ship all changes to the production env (and this new endpoint is added and the old one removed), I'll send another PR to switch from `data-jsdelivr-com-preview.onrender.com` to `data.jsdelivr.com`