### PR TITLE
Fix bug that identify wrongly some TS packages as Definetely Typed 

### DIFF
--- a/src/typescript/index.ts
+++ b/src/typescript/index.ts
@@ -86,7 +86,6 @@ export function getTypeScriptSupport(
         },
       };
     }
-
     datadog.increment('jsdelivr.getTSSupport.miss');
 
     return { types: { ts: false } };

--- a/src/typescript/index.ts
+++ b/src/typescript/index.ts
@@ -66,6 +66,16 @@ export function getTypeScriptSupport(
       return { types: pkg.types };
     }
 
+    for (const file of filelist) {
+      if (!file.name.endsWith('.d.ts')) {
+        continue;
+      }
+
+      datadog.increment('jsdelivr.getTSSupport.hit');
+
+      return { types: { ts: 'included' } };
+    }
+
     // The 2nd most likely is definitely typed
     const defTyped = isDefinitelyTyped({ name: pkg.name });
     if (defTyped) {
@@ -77,15 +87,6 @@ export function getTypeScriptSupport(
       };
     }
 
-    for (const file of filelist) {
-      if (!file.name.endsWith('.d.ts')) {
-        continue;
-      }
-
-      datadog.increment('jsdelivr.getTSSupport.hit');
-
-      return { types: { ts: 'included' } };
-    }
     datadog.increment('jsdelivr.getTSSupport.miss');
 
     return { types: { ts: false } };


### PR DESCRIPTION
This PR solves the issue that appears to be a data problem with `npm-search` index listing yup (we've only seen a single library so far) as non-TS library.

To solve it, applies the suggestion by @jablko and reverse the logic in the `getTypeScriptSupport` function, preventing yup, or other libraries written in TypeScript from being flagged as definitely typed even if an outdated/deprecated Definitely Typed reference exists.

closes https://github.com/algolia/npm-search/issues/1089