### PR TITLE
Migrating from CircleCI to GitHub Actions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,31 @@
+name: Validate
+run-name: 🤖 Validating code on ${{ github.ref_name }}
+
+on:
+  push:
+
+jobs:
+  validate:
+    name: 🤖 Validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📁 Checkout code
+        uses: actions/checkout@v4
+
+      - name: ⚙️ Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.18'
+          cache: 'yarn'
+
+      - name: 📦 Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: 📝 Lint
+        run: yarn lint
+
+      - name: 🏗️ Build
+        run: yarn build
+
+      - name: 🚦 Test
+        run: yarn test


### PR DESCRIPTION
This is the first step in migrating from CircleCI to GitHub Actions. I only replicated the Lint/Build/Test jobs on GitHub Actions for now.

Next step, I will move (and fix) the release job so we can publish new docker images. Once this PR is merged, I'll also shut down CircleCI so we do not have two CI tools running at the same time.
