### PR TITLE
fix(ci): Trigger CI checks on branch push, not only on PR creation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,7 +2,10 @@ name: Validate
 run-name: 🤖 Validating code on ${{ github.ref_name }}
 
 on:
-  pull_request:
+  push:
+    branches-ignore:
+      # master already has validate as part of its publish workflow
+      - master
   # on.workflow_call is required for this workflow to be re-used
   # See: https://docs.github.com/en/actions/using-workflows/reusing-workflows#creating-a-reusable-workflow
   workflow_call:


### PR DESCRIPTION
I'm updating the `validate` workflow to trigger on each push, not only when a PR is created.

This is how the config on CircleCI used to work and allow to check the status of the checks before actually creating a PR (thus avoiding noise as one can debug checks without creating a PR for that)