### PR TITLE
fix: add package name to all records

### DIFF
--- a/src/indexers/MainBootstrapIndexer.ts
+++ b/src/indexers/MainBootstrapIndexer.ts
@@ -79,6 +79,7 @@ export class MainBootstrapIndexer extends MainIndexer<TaskType> {
 
         await this.algoliaStore.bootstrapNotFoundIndex
           .saveObject({
+            name: pkg.id,
             objectID: pkg.id,
             err: err instanceof Error ? err.toString() : err,
             date: new Date().toISOString(),

--- a/src/indexers/MainWatchIndexer.ts
+++ b/src/indexers/MainWatchIndexer.ts
@@ -14,6 +14,7 @@ import { MainIndexer } from './MainIndexer';
 
 type TaskType = {
   seq: number;
+  name: string;
   objectID: string;
   retries: number;
   change: DatabaseChangesResultItem;
@@ -118,6 +119,7 @@ export class MainWatchIndexer extends MainIndexer<TaskType> {
 
         await this.algoliaStore.mainNotFoundIndex
           .saveObject({
+            name: change.id,
             objectID: change.id,
             err: err instanceof Error ? err.toString() : err,
             date: new Date().toISOString(),

--- a/src/indexers/OneTimeBackgroundIndexer.ts
+++ b/src/indexers/OneTimeBackgroundIndexer.ts
@@ -10,6 +10,7 @@ import { offsetToTimestamp } from '../utils/time';
 import { Indexer } from './Indexer';
 
 export type OneTimeDataObject = {
+  name: string;
   objectID: string;
   updatedAt: string;
   changelogFilename: string | null;
@@ -60,6 +61,7 @@ export class OneTimeBackgroundIndexer extends Indexer<FinalPkg> {
         : await getChangelogBackground(pkg);
 
       const data = {
+        name: `${pkg.name}@${pkg.version}`,
         objectID: `${pkg.name}@${pkg.version}`,
         updatedAt: new Date().toISOString(),
         changelogFilename,

--- a/src/indexers/PeriodicBackgroundIndexer.ts
+++ b/src/indexers/PeriodicBackgroundIndexer.ts
@@ -16,6 +16,7 @@ import { offsetToTimestamp, round } from '../utils/time';
 import { Indexer } from './Indexer';
 
 export type PeriodicDataObject = DownloadsData & {
+  name: string;
   objectID: string;
   updatedAt: string;
 };
@@ -86,6 +87,7 @@ export class PeriodicBackgroundIndexer extends Indexer<FinalPkg, Task> {
         task.pkg,
         async (pkg) => {
           const data: PeriodicDataObject = {
+            name: pkg.name,
             objectID: pkg.name,
             updatedAt: new Date().toISOString(),
             totalNpmDownloads: downloads[pkg.name]?.totalNpmDownloads,
@@ -110,6 +112,7 @@ export class PeriodicBackgroundIndexer extends Indexer<FinalPkg, Task> {
                 datadog.increment('periodic.notFound');
 
                 await this.notFoundIndex.saveObject({
+                  name: pkg.name,
                   objectID: pkg.name,
                   date: new Date().toISOString(),
                   movedBy: 'periodicIndexer',

--- a/src/npm/Prefetcher.ts
+++ b/src/npm/Prefetcher.ts
@@ -91,6 +91,7 @@ export class Prefetcher {
 
       await this.queueIndex.saveObjects(
         packages.map((pkg) => ({
+          name: pkg.id,
           objectID: pkg.id,
           retries: 0,
           pkg,

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -134,6 +134,7 @@ export class Watch {
             await this.algoliaStore.mainQueueIndex.saveObjects(
               changes.map((change) => ({
                 seq: change.seq,
+                name: change.id,
                 objectID: change.id,
                 retries: 0,
                 change,


### PR DESCRIPTION
We use the package name as `objectID` in the helper indexes, but `objectID` is not searchable, which makes it very hard to interact with the indexes via the UI (for debugging). This adds the package name as an additional searchable attribute to all the data indexes and queues.