### PR TITLE
feat: alternative names for css packages

### DIFF
--- a/src/__tests__/formatPkg.test.ts
+++ b/src/__tests__/formatPkg.test.ts
@@ -462,6 +462,36 @@ describe('alternative names', () => {
     `);
   });
 
+  it('name ending in .css', () => {
+    const pkg: GetPackage = {
+      ...BASE,
+      name: 'animate.css',
+    };
+    expect(formatPkg(pkg)!._searchInternal.alternativeNames)
+      .toMatchInlineSnapshot(`
+      Array [
+        "animatecss",
+        "animate css",
+        "animate",
+        "animate.css",
+      ]
+    `);
+  });
+
+  it('name ending in css', () => {
+    const pkg: GetPackage = {
+      ...BASE,
+      name: 'tailwindcss',
+    };
+    expect(formatPkg(pkg)!._searchInternal.alternativeNames)
+      .toMatchInlineSnapshot(`
+      Array [
+        "tailwindcss",
+        "tailwind",
+      ]
+    `);
+  });
+
   it('scoped package', () => {
     const pkg: GetPackage = {
       ...BASE,

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,7 +49,7 @@ const indexSettings: Settings = {
     'custom',
   ],
   minProximity: 5,
-  optionalWords: ['js', 'javascript'],
+  optionalWords: ['js', 'javascript', 'css'],
   separatorsToIndex: '_',
   replaceSynonymsInHighlight: false,
   maxValuesPerFacet: 1000,

--- a/src/formatPkg.ts
+++ b/src/formatPkg.ts
@@ -568,13 +568,10 @@ function getAlternativeNames(name: string): string[] {
   const splitName = name.replace(/[-/@_.]+/g, ' ');
   alternativeNames.add(splitName);
 
-  const isDotJs = name.endsWith('.js');
-  const isJsSuffix = name.match(/\.?js$/);
+  const suffixLength = name.match(/\.?(js|css)$/)?.[0].length;
 
-  if (isDotJs) {
-    alternativeNames.add(name.substring(0, name.length - 3));
-  } else if (isJsSuffix) {
-    alternativeNames.add(name.substring(0, name.length - 2));
+  if (suffixLength) {
+    alternativeNames.add(name.substring(0, name.length - suffixLength));
   } else {
     alternativeNames.add(`${name}.js`);
     alternativeNames.add(`${name}js`);


### PR DESCRIPTION
Improves ranking for `tailwindcss` and similar using the same logic that was used for `js` suffixes.