### PR TITLE
feat: allow `owners.name` to be facetable

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@ const indexSettings: Settings = {
     'searchable(keywords)',
     'searchable(computedKeywords)',
     'searchable(owner.name)',
+    'searchable(owners.name)',
     '_oneTimeDataToUpdateAt',
     '_periodicDataUpdatedAt',
     'deprecated',


### PR DESCRIPTION
There is no reliable way to filter packages down to ones maintained by a given npm user. 

The current `owner` field is, as called out by the docs, the github user not the actual npm user. Which is surprising! 

This change would allow filtering by the actual npm user who is a maintainer (aka appears in the maintainers array, which is the closest public concept of an "owner" as npm exposes). 

The PR itself doesnt change the semantics of the currwnt `owner` field, just makes it so folks can filter to the `ownerS` array. 

See npmx.dev related issue: https://github.com/npmx-dev/npmx.dev/issues/2504